### PR TITLE
chore: repo hygiene — LICENSE, .gitignore, README baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,16 +8,29 @@
 # testing
 /coverage
 
-# production
+# production / build output
 /build
+/dist
+/storybook-static
 
-# misc
-.DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+# environment
+.env
+.env.*
+!.env.example
 
+# logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+*.log
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Claude scratch / planning docs (only README.md allowed in repo)
+*.plan.md
+audit-*.md
+claude-*.md
+notes/
+.claude/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Miguel Lozano
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,78 +1,60 @@
-# Getting Started with Create React App
+# Miguel Lozano — Portfolio
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+> _[TODO: Miguel — one-line tagline / personal voice. Example: "Front-end engineer building thoughtful, accessible web experiences."]_
 
-## Available Scripts
+**Live site:** [migueldotl.github.io](https://migueldotl.github.io)
 
-In the project directory, you can run:
+---
 
-### `npm start`
+## About
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
+_[TODO: Miguel — short paragraph in your own voice: who you are, what you build, what you care about. This is the first thing recruiters read after the live site, so it should feel like you, not me.]_
 
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
+## Tech stack
 
-### `npm test`
+- **Framework:** React 18
+- **Styling:** Bootstrap 5 + custom CSS
+- **Build:** Create React App _(migration to Vite in progress — see [#15](https://github.com/MiguelDotL/react-portfolio/issues/15))_
+- **Hosting:** GitHub Pages (built artifact pushed to [`migueldotl.github.io`](https://github.com/MiguelDotL/migueldotl.github.io))
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+## Local development
 
-### `npm run build`
+```bash
+git clone https://github.com/MiguelDotL/react-portfolio.git
+cd react-portfolio
+npm install
+npm start
+```
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
+App runs at [http://localhost:3000](http://localhost:3000).
 
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
+## Build
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+```bash
+npm run build
+```
 
-### `npm run eject`
+Outputs to `build/` (will become `dist/` post-Vite migration).
 
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
+## Project structure
 
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+```
+src/
+├── components/    # React components (NavBar, Hero, Projects, Skills, ContactForm, ...)
+├── apis/          # External API clients (form backend)
+├── assets/
+│   ├── images/    # Project screenshots, icons, backgrounds
+│   ├── fonts/     # Custom fonts
+│   └── styles/    # Component-specific CSS
+└── index.js       # Entry point
+```
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
+## Credits
 
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
+- Hero background image: [Freepik](https://www.freepik.com/free-vector/gradient-galaxy-background_14212522.htm)
+- Skill and tooling icons: [DevIcons](https://devicon.dev/)
+- Social and educational icons: [SVG Repo](https://www.svgrepo.com/)
 
-## Learn More
+## License
 
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-### Analyzing the Bundle Size
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
-
-### Making a Progressive Web App
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
-
-### Advanced Configuration
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `npm run build` fails to minify
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
-
-# react-portfolio
-
-### Credits
-
--   Hero Background Image: [Freepik](https://www.freepik.com/free-vector/gradient-galaxy-background_14212522.htm#position=13)
--   Skill and Tooling SVG Icons: [DevIcons](https://devicon.dev/)
--   Social and Educational SVG Icons: [SVG Repo](https://www.svgrepo.com/)
+[MIT](./LICENSE) © 2026 Miguel Lozano


### PR DESCRIPTION
## Summary

First-priority hygiene work per the project plan — must land before any other code commits to prevent leaking secrets/scratch docs.

- Add MIT `LICENSE` (2026, Miguel Lozano)
- Polish `.gitignore`:
  - Add `dist/`, `storybook-static/` for upcoming Vite + Storybook work
  - Tighten env handling: `.env`, `.env.*` with `!.env.example` whitelist
  - Add `*.log`, `Thumbs.db`
  - **Block all Claude scratch / planning docs** (`*.plan.md`, `audit-*.md`, `claude-*.md`, `notes/`, `.claude/`) — only `README.md` allowed in repo
- Replace CRA-default `README.md` with portfolio-specific skeleton
  - Live link, tech stack, local dev, build, project structure, credits, license
  - Two `[TODO: Miguel]` markers in tagline + About — to be filled with personal voice before merging

## Test plan

- [ ] Miguel fills in tagline and About sections in the README
- [ ] Verify `.gitignore` patterns work — try `touch test.plan.md` then `git status` should ignore it
- [ ] Verify LICENSE renders properly on GitHub repo page

Closes #32