### PR TITLE
test: add Jest + RTL component tests (Tier 1 + Tier 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,12 @@
       "react-app/jest"
     ]
   },
+  "jest": {
+    "transformIgnorePatterns": [
+      "node_modules/(?!(axios)/).+\\.(js|jsx|mjs|cjs|ts|tsx)$",
+      "^.+\\.module\\.(css|sass|scss)$"
+    ]
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,0 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/components/App.test.js
+++ b/src/components/App.test.js
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import App from './App';
+
+describe('App', () => {
+    test('renders without crashing and mounts every section', () => {
+        render(<App />);
+        // Hero
+        expect(screen.getByRole('heading', { name: /Hi, I'm Miguel!/i })).toBeInTheDocument();
+        // Skills
+        expect(screen.getByRole('heading', { name: /^Skills$/i })).toBeInTheDocument();
+        // Projects
+        expect(screen.getByRole('heading', { name: /^Projects$/i })).toBeInTheDocument();
+        // Contact (rendered twice — h2 + h3 for responsive variants)
+        expect(screen.getAllByRole('heading', { name: /Wanna Hire Me/i }).length).toBeGreaterThan(0);
+    });
+});

--- a/src/components/ContactForm.test.js
+++ b/src/components/ContactForm.test.js
@@ -1,0 +1,71 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ContactForm from './ContactForm';
+import getForm from '../apis/getForm';
+
+jest.mock('../apis/getForm');
+
+describe('ContactForm', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('renders all form fields and submit button', () => {
+        render(<ContactForm />);
+        expect(screen.getByPlaceholderText(/First Name/i)).toBeInTheDocument();
+        expect(screen.getByPlaceholderText(/Last Name/i)).toBeInTheDocument();
+        expect(screen.getByPlaceholderText(/Email Address/i)).toBeInTheDocument();
+        expect(screen.getByPlaceholderText(/Phone Number/i)).toBeInTheDocument();
+        expect(screen.getByPlaceholderText(/Message/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /send/i })).toBeInTheDocument();
+    });
+
+    test('updates input values when user types', () => {
+        render(<ContactForm />);
+
+        const firstName = screen.getByPlaceholderText(/First Name/i);
+        userEvent.type(firstName, 'Miguel');
+        expect(firstName).toHaveValue('Miguel');
+
+        const email = screen.getByPlaceholderText(/Email Address/i);
+        userEvent.type(email, 'test@example.com');
+        expect(email).toHaveValue('test@example.com');
+    });
+
+    test('submits form with values and shows success message', async () => {
+        getForm.post.mockResolvedValueOnce({ status: 200, data: { success: true } });
+
+        render(<ContactForm />);
+
+        userEvent.type(screen.getByPlaceholderText(/First Name/i), 'Miguel');
+        userEvent.type(screen.getByPlaceholderText(/Email Address/i), 'a@b.com');
+        userEvent.type(screen.getByPlaceholderText(/Message/i), 'Hello!');
+        userEvent.click(screen.getByRole('button', { name: /send/i }));
+
+        await waitFor(() => {
+            expect(getForm.post).toHaveBeenCalledTimes(1);
+        });
+
+        const [, payload] = getForm.post.mock.calls[0];
+        expect(payload.firstName).toBe('Miguel');
+        expect(payload.email).toBe('a@b.com');
+        expect(payload.message).toBe('Hello!');
+
+        await waitFor(() => {
+            expect(screen.getByText(/Thanks for reaching out/i)).toBeInTheDocument();
+        });
+    });
+
+    test('shows error message when submission fails', async () => {
+        getForm.post.mockRejectedValueOnce(new Error('Network down'));
+
+        render(<ContactForm />);
+
+        userEvent.type(screen.getByPlaceholderText(/First Name/i), 'Miguel');
+        userEvent.click(screen.getByRole('button', { name: /send/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText(/Oops! Network down/i)).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/HeroContent.test.js
+++ b/src/components/HeroContent.test.js
@@ -1,0 +1,40 @@
+import { act, render, screen } from '@testing-library/react';
+import HeroContent from './HeroContent';
+
+describe('HeroContent', () => {
+    test('renders intro greeting', () => {
+        render(<HeroContent />);
+        expect(screen.getByRole('heading', { name: /Hi, I'm Miguel!/i })).toBeInTheDocument();
+    });
+
+    test('renders bio paragraph and Lets Chat CTA', () => {
+        render(<HeroContent />);
+        expect(screen.getByText(/journey into programming began in 2005/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Let's Chat/i })).toBeInTheDocument();
+    });
+
+    test('calculates years of experience from 2016', () => {
+        render(<HeroContent />);
+        const expectedYears = new Date().getFullYear() - 2016;
+        expect(screen.getByText(`${expectedYears} years`)).toBeInTheDocument();
+    });
+
+    test('typing animation populates jobTitle over time', () => {
+        jest.useFakeTimers();
+        render(<HeroContent />);
+
+        // typing-text starts empty
+        const typingElement = document.querySelector('.typing-text');
+        expect(typingElement.textContent).toBe('');
+
+        // advance ~1.5s of typing — should have populated some characters from "Front-End"
+        act(() => {
+            jest.advanceTimersByTime(1500);
+        });
+
+        expect(typingElement.textContent.length).toBeGreaterThan(0);
+        expect('Front-End'.startsWith(typingElement.textContent)).toBe(true);
+
+        jest.useRealTimers();
+    });
+});

--- a/src/components/NavBar.test.js
+++ b/src/components/NavBar.test.js
@@ -1,0 +1,33 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import NavBar from './NavBar';
+
+describe('NavBar', () => {
+    test('renders brand and all nav links', () => {
+        render(<NavBar />);
+        expect(screen.getByText(/MIGUEL/i)).toBeInTheDocument();
+        expect(screen.getByText(/LOZANO/i)).toBeInTheDocument();
+
+        ['Home', 'Skills', 'Projects', 'Contact'].forEach((link) => {
+            expect(screen.getByRole('link', { name: link })).toBeInTheDocument();
+        });
+    });
+
+    test('renders resume button', () => {
+        render(<NavBar />);
+        expect(screen.getByRole('button', { name: /My Resume/i })).toBeInTheDocument();
+    });
+
+    test('toggles has-scrolled class when window scrolls past 50px', () => {
+        const { container } = render(<NavBar />);
+        const navbar = container.querySelector('.navbar');
+
+        expect(navbar.className).not.toMatch(/has-scrolled/);
+
+        act(() => {
+            Object.defineProperty(window, 'scrollY', { value: 100, writable: true });
+            fireEvent.scroll(window);
+        });
+
+        expect(navbar.className).toMatch(/has-scrolled/);
+    });
+});

--- a/src/components/Projects.test.js
+++ b/src/components/Projects.test.js
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Projects from './Projects';
+
+describe('Projects', () => {
+    test('renders Projects heading and intro copy', () => {
+        render(<Projects />);
+        expect(screen.getByRole('heading', { name: /^Projects$/i })).toBeInTheDocument();
+        expect(screen.getByText(/Royal Caribbean International/i)).toBeInTheDocument();
+    });
+
+    test('renders all six client projects on default tab', () => {
+        render(<Projects />);
+        const clientProjectTitles = [
+            'T R I M Agency',
+            'C Solutions',
+            'Orby TV',
+            'Federated Insurance',
+            'Filthy Food',
+            'General Provision'
+        ];
+
+        clientProjectTitles.forEach((title) => {
+            expect(screen.getByRole('heading', { name: title })).toBeInTheDocument();
+        });
+    });
+
+    test('Personal and Misc tabs render and update aria-selected on click', () => {
+        render(<Projects />);
+
+        const clientTab = screen.getByRole('tab', { name: /Client Projects/i });
+        const personalTab = screen.getByRole('tab', { name: /Personal Projects/i });
+        const miscTab = screen.getByRole('tab', { name: /Misc\. Projects/i });
+
+        expect(clientTab).toHaveAttribute('aria-selected', 'true');
+        expect(personalTab).toHaveAttribute('aria-selected', 'false');
+        expect(miscTab).toHaveAttribute('aria-selected', 'false');
+
+        userEvent.click(personalTab);
+        expect(personalTab).toHaveAttribute('aria-selected', 'true');
+        expect(clientTab).toHaveAttribute('aria-selected', 'false');
+
+        userEvent.click(miscTab);
+        expect(miscTab).toHaveAttribute('aria-selected', 'true');
+        expect(personalTab).toHaveAttribute('aria-selected', 'false');
+    });
+});

--- a/src/components/Skills.test.js
+++ b/src/components/Skills.test.js
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import Skills from './Skills';
+
+describe('Skills', () => {
+    test('renders Skills heading and copy', () => {
+        render(<Skills />);
+        expect(screen.getByRole('heading', { name: /^Skills$/i })).toBeInTheDocument();
+        expect(screen.getByText(/I love trying out new technologies/i)).toBeInTheDocument();
+    });
+
+    test('mounts the carousel without crashing', () => {
+        const { container } = render(<Skills />);
+        expect(container.querySelector('.skills-content')).toBeInTheDocument();
+    });
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,5 +1,40 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+class IntersectionObserverMock {
+    constructor(callback) {
+        this.callback = callback;
+    }
+    observe = (target) => {
+        this.callback([{ isIntersecting: true, target }], this);
+    };
+    unobserve = () => {};
+    disconnect = () => {};
+    takeRecords = () => [];
+    root = null;
+    rootMargin = '';
+    thresholds = [];
+}
+
+class ResizeObserverMock {
+    observe = () => {};
+    unobserve = () => {};
+    disconnect = () => {};
+}
+
+global.IntersectionObserver = IntersectionObserverMock;
+global.ResizeObserver = ResizeObserverMock;
+
+window.matchMedia =
+    window.matchMedia ||
+    ((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false
+    }));
+
+Element.prototype.scrollIntoView = Element.prototype.scrollIntoView || (() => {});


### PR DESCRIPTION
## Summary

Adds component test coverage to provide a regression safety net for upcoming work (typo fixes, React-key cleanup, alt-text changes, react-on-screen replacement, useEffect bug fix, etc.).

Uses CRA's existing Jest + React Testing Library setup. Will be ported to Vitest as part of the Vite migration (#15) — Vitest is API-compatible so the port is mostly mechanical.

## What's covered

- **App** — full-tree smoke test (asserts every section mounts)
- **HeroContent** — intro text, bio + CTA, years-of-experience calc, typing animation populates jobTitle
- **ContactForm** — all fields render, input updates, success submission flow (with mocked axios), error path
- **Projects** — heading, all 6 client projects render, tab switching via `aria-selected`
- **NavBar** — brand + nav links + resume button, scroll-class toggle on `window.scroll`
- **Skills** — heading and carousel mount

**17 tests passing across 6 suites.**

## Infra changes

- Replaced broken CRA-default `src/App.test.js` (wrong import path, looked for "learn react" text) with co-located `src/components/App.test.js`
- `setupTests.js` adds jsdom polyfills: IntersectionObserver, ResizeObserver, scrollIntoView, matchMedia (needed by react-on-screen, react-multi-carousel, and HeroContent's scrollIntoView CTA)
- `package.json` jest config: scoped `transformIgnorePatterns` to allow axios transformation while preserving CRA's default CSS-module pattern

## Test plan

- [ ] `CI=true npm test -- --watchAll=false` — all 17 tests pass
- [ ] Tests run in ~5s

Closes #33