### PR TITLE
fix: encype -> encType in ContactForm

### DIFF
--- a/src/components/ContactForm.js
+++ b/src/components/ContactForm.js
@@ -64,7 +64,7 @@ const ContactForm = () => {
     };
 
     return (
-        <form encype="multipart/form-data" onSubmit={onFormSubmit}>
+        <form encType="multipart/form-data" onSubmit={onFormSubmit}>
             <Row>
                 <Col className="px-1" sm={6}>
                     <input


### PR DESCRIPTION
## Summary

One-line typo fix in `src/components/ContactForm.js` line 67. React was silently ignoring the misspelled `encype` prop, so this is code cleanup with no functional impact.

## Test plan

- [x] `CI=true npm test -- --watchAll=false` — all 17 tests pass

Closes #23