### PR TITLE
fix: replace array-index React keys

### DIFF
--- a/src/components/ProjectList.js
+++ b/src/components/ProjectList.js
@@ -5,8 +5,8 @@ const ProjectList = ({ projects, eventKey }) => {
     return (
         <Tab.Pane eventKey={eventKey}>
             <Row>
-                {projects.map((project, index) => {
-                    return <ProjectCard key={index} {...project} />;
+                {projects.map((project) => {
+                    return <ProjectCard key={project.url} {...project} />;
                 })}
             </Row>
         </Tab.Pane>

--- a/src/components/SkillsCarousel.js
+++ b/src/components/SkillsCarousel.js
@@ -50,9 +50,9 @@ const SkillsCarousel = () => {
             infinite={true}
             swipeable={true}
         >
-            {skills.map((skill, index) => {
+            {skills.map((skill) => {
                 return (
-                    <div key={index} className="item">
+                    <div key={skill.name} className="item">
                         <i
                             className={`devicon devicon-${skill.class} colored`}
                             style={{ color: skill.color }}


### PR DESCRIPTION
## Summary

Replace `key={index}` with stable identifiers in two list renders:
- `src/components/ProjectList.js` → `key={project.url}` (each client project URL is unique)
- `src/components/SkillsCarousel.js` → `key={skill.name}` (each skill name is unique)

Array indices as keys are an anti-pattern that can cause subtle re-render and animation bugs when lists change. With stable keys, React reuses DOM nodes correctly.

## Test plan

- [x] `CI=true npm test -- --watchAll=false` — all 17 tests pass
- [ ] Visual: dev server should render Projects + Skills identically

Closes #21