### PR TITLE
feat: a11y pass — alt text, aria-labels, prefers-reduced-motion

### DIFF
--- a/src/components/ContactForm.js
+++ b/src/components/ContactForm.js
@@ -72,6 +72,7 @@ const ContactForm = () => {
                         name="firstName"
                         value={formValues.firstName}
                         placeholder="First Name"
+                        aria-label="First Name"
                         onChange={onFormChange()}
                     />
                 </Col>
@@ -81,6 +82,7 @@ const ContactForm = () => {
                         name="lastName"
                         value={formValues.lastName}
                         placeholder="Last Name"
+                        aria-label="Last Name"
                         onChange={onFormChange()}
                     />
                 </Col>
@@ -92,6 +94,7 @@ const ContactForm = () => {
                         name="email"
                         value={formValues.email}
                         placeholder="Email Address"
+                        aria-label="Email Address"
                         onChange={onFormChange()}
                     />
                 </Col>
@@ -101,6 +104,7 @@ const ContactForm = () => {
                         name="phone"
                         value={formValues.phone}
                         placeholder="Phone Number"
+                        aria-label="Phone Number"
                         onChange={onFormChange()}
                     />
                 </Col>
@@ -111,6 +115,7 @@ const ContactForm = () => {
                         rows="6"
                         value={formValues.message}
                         placeholder="Message"
+                        aria-label="Message"
                         onChange={onFormChange()}
                     />
                 </Col>

--- a/src/components/ContactMe.js
+++ b/src/components/ContactMe.js
@@ -19,7 +19,10 @@ const ContactMe = () => {
                                     }`}
                                 >
                                     <h2 className="hire-me nowrap">Wanna Hire Me?</h2>
-                                    <img className="" src={contactImage} alt="" />
+                                    <img
+                                        src={contactImage}
+                                        alt="Caricature of Miguel working at a laptop"
+                                    />
                                 </div>
                             )}
                         </TrackVisibility>

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -14,27 +14,32 @@ const socialsConfig = [
     {
         className: "codepen",
         icon: codepenIcon,
-        url: "//codepen.io/MiguelDotL"
+        url: "//codepen.io/MiguelDotL",
+        label: "CodePen"
     },
     {
         className: "codewars",
         icon: codewarsIcon,
-        url: "//www.codewars.com/users/MiguelDotL"
+        url: "//www.codewars.com/users/MiguelDotL",
+        label: "Codewars"
     },
     {
         className: "codecademy",
         icon: codecademyIcon,
-        url: "//www.codecademy.com/profiles/MiguelDotL"
+        url: "//www.codecademy.com/profiles/MiguelDotL",
+        label: "Codecademy"
     },
     {
         className: "udemy",
         icon: udemyIcon,
-        url: "//www.udemy.com/user/miguel-lozano-4/"
+        url: "//www.udemy.com/user/miguel-lozano-4/",
+        label: "Udemy"
     },
     {
         className: "duolingo",
         icon: duolingoIcon,
-        url: "//www.duolingo.com/profile/MiguelDotL"
+        url: "//www.duolingo.com/profile/MiguelDotL",
+        label: "Duolingo"
     }
 ];
 

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -28,18 +28,21 @@ const NavBar = () => {
         {
             className: 'linked-in',
             icon: linkedInIcon,
-            url: 'https://www.linkedin.com/in/migueldot/'
+            url: 'https://www.linkedin.com/in/migueldot/',
+            label: 'LinkedIn'
         },
         {
             className: 'twitter',
             icon: twitterXIcon,
             // icon: twitterIcon,
-            url: '//twitter.com/MiguelDotL'
+            url: '//twitter.com/MiguelDotL',
+            label: 'X (Twitter)'
         },
         {
             className: 'github',
             icon: githubIcon,
-            url: '//github.com/MiguelDotL'
+            url: '//github.com/MiguelDotL',
+            label: 'GitHub'
         }
     ];
 

--- a/src/components/SocialIcons.js
+++ b/src/components/SocialIcons.js
@@ -11,8 +11,9 @@ const SocialIcons = ({ config }) => {
                         href={social.url}
                         target="_blank"
                         rel="noreferrer"
+                        aria-label={social.label}
                     >
-                        <img src={social.icon} alt="" />
+                        <img src={social.icon} alt={social.label} />
                     </a>
                 );
             })}

--- a/src/index.css
+++ b/src/index.css
@@ -285,3 +285,15 @@ p.copy {
   -webkit-animation-name: fadeInLeft;
   animation-name: fadeInLeft;
 }
+
+/* ==== Reduced motion preference ==== */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary

Accessibility improvements across the site.

### Alt text
- `SocialIcons.js` now renders alt from new `social.label` field (was empty `alt=""`)
- `NavBar` socialsConfig: added labels — LinkedIn, X (Twitter), GitHub
- `Footer` socialsConfig: added labels — CodePen, Codewars, Codecademy, Udemy, Duolingo
- `ContactMe.js`: bitmoji image now has descriptive alt

### Form labels
- `ContactForm.js`: every input + textarea gets an `aria-label` (placeholders alone aren't accessible — they disappear when typing and aren't reliably announced by screen readers)

### Motion preference
- `index.css`: added `@media (prefers-reduced-motion: reduce)` rule that disables CSS animations and transitions for users who request reduced motion (W3C-recommended pattern)

## Test plan

- [x] `CI=true npm test -- --watchAll=false` — all 17 tests pass
- [ ] Visual: dev server should render identically (alt text and aria-label are invisible to sighted users)
- [ ] Lighthouse Accessibility score should improve once #28 lands

Closes #19