### PR TITLE
feat: add robots.txt + sitemap.xml

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,5 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Allow: /
+
+Sitemap: https://migueldotl.github.io/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>https://migueldotl.github.io/</loc>
+        <lastmod>2026-04-30</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>1.0</priority>
+    </url>
+</urlset>


### PR DESCRIPTION
## Summary

SEO basics for the static site.

- `public/robots.txt`: explicit `Allow: /` and link to sitemap (was just `Disallow:` with empty path before — semantically same as allow, but unclear)
- `public/sitemap.xml`: single root URL entry with `lastmod`, `changefreq`, `priority`

CRA copies `public/*` to the build output as-is, so these will be served at the site root once deployed.

## Test plan

- [ ] After deploy: `https://migueldotl.github.io/robots.txt` and `/sitemap.xml` return 200 with the right content

Closes #18