### PR TITLE
feat: replace react-on-screen with react-intersection-observer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
         "react-bootstrap": "^2.5.0",
         "react-bootstrap-icons": "^1.9.1",
         "react-dom": "^18.2.0",
+        "react-intersection-observer": "^10.0.3",
         "react-multi-carousel": "^2.8.2",
-        "react-on-screen": "^2.1.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       }
@@ -64,6 +64,7 @@
       "version": "7.19.6",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.6.tgz",
       "integrity": "sha512-D2Ue4KHpc6Ys2+AxpIx1BZ8+UegLLLE2p3KJEuJRKmokHOtl49jQ5ny1773KsGLZs8MQvBidAF6yWUJxRqtKtg==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -873,6 +874,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.18.6.tgz",
       "integrity": "sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6"
       },
@@ -1433,6 +1435,7 @@
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.19.0.tgz",
       "integrity": "sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-module-imports": "^7.18.6",
@@ -3096,6 +3099,7 @@
       "version": "2.11.6",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
       "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -4254,6 +4258,7 @@
       "version": "5.40.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.40.1.tgz",
       "integrity": "sha512-FsWboKkWdytGiXT5O1/R9j37YgcjO8MKHSUmWnIEjVaz0krHkplPnYi7mwdb+5+cs0toFNQb0HIrN7zONdIEWg==",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.40.1",
         "@typescript-eslint/type-utils": "5.40.1",
@@ -4303,6 +4308,7 @@
       "version": "5.40.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.40.1.tgz",
       "integrity": "sha512-IK6x55va5w4YvXd4b3VrXQPldV9vQTxi5ov+g4pMANsXPTXOcfjx08CRR1Dfrcc51syPtXHF5bgLlMHYFrvQtg==",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.40.1",
         "@typescript-eslint/types": "5.40.1",
@@ -4628,6 +4634,7 @@
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
       "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4735,6 +4742,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5503,6 +5511,7 @@
           "url": "https://tidelift.com/funding/github/npm/browserslist"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001400",
         "electron-to-chromium": "^1.4.251",
@@ -6117,6 +6126,7 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -7030,6 +7040,7 @@
       "version": "8.25.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
       "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
+      "peer": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.3",
         "@humanwhocodes/config-array": "^0.10.5",
@@ -7432,6 +7443,7 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -9466,6 +9478,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -11609,11 +11622,6 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
     },
-    "node_modules/lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
-    },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -11825,6 +11833,7 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -12559,6 +12568,7 @@
           "url": "https://tidelift.com/funding/github/npm/postcss"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -13614,6 +13624,7 @@
       "version": "6.0.10",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
       "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -13975,6 +13986,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -14159,6 +14171,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -14171,6 +14184,21 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-10.0.3.tgz",
+      "integrity": "sha512-luICLMbs0zxTO/70Zy7K5jOXkABPEVSAF8T3FdZUlctsrIaPLmx8TZe2SSA+CY2HGWfz2INyNTnp82pxNNsShA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",
@@ -14190,24 +14218,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/react-on-screen": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-on-screen/-/react-on-screen-2.1.1.tgz",
-      "integrity": "sha512-mV2Ntd61ncJ9nBsXF/p5Y6lMDGTTwXTGvHaal4b7O1eX3GwSwDXKAe7KKXTf/4Oc1BuYc7j5Sy0XdT89w/MjDA==",
-      "dependencies": {
-        "lodash.throttle": "^4.1.1",
-        "prop-types": "^15.6.0",
-        "shallowequal": "^1.0.2"
-      },
-      "peerDependencies": {
-        "react": ">=15.0.0",
-        "react-dom": ">=15.0.0"
-      }
-    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14641,6 +14656,7 @@
       "version": "2.79.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
       "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -15014,11 +15030,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
-    },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -15885,6 +15896,7 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -16206,6 +16218,7 @@
       "version": "5.74.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
       "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -16274,6 +16287,7 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -16323,6 +16337,7 @@
       "version": "4.11.1",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.11.1.tgz",
       "integrity": "sha512-lILVz9tAUy1zGFwieuaQtYiadImb5M3d+H+L1zDYalYoDl0cksAB1UNyuE5MMWJrG6zR1tXkCP2fitl7yoUJiw==",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -16377,6 +16392,7 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -16694,6 +16710,7 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -17094,6 +17111,7 @@
       "version": "7.19.6",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.6.tgz",
       "integrity": "sha512-D2Ue4KHpc6Ys2+AxpIx1BZ8+UegLLLE2p3KJEuJRKmokHOtl49jQ5ny1773KsGLZs8MQvBidAF6yWUJxRqtKtg==",
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -17647,6 +17665,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.18.6.tgz",
       "integrity": "sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==",
+      "peer": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.18.6"
       }
@@ -17991,6 +18010,7 @@
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.19.0.tgz",
       "integrity": "sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==",
+      "peer": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-module-imports": "^7.18.6",
@@ -19121,7 +19141,8 @@
     "@popperjs/core": {
       "version": "2.11.6",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+      "peer": true
     },
     "@react-aria/ssr": {
       "version": "3.3.0",
@@ -20020,6 +20041,7 @@
       "version": "5.40.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.40.1.tgz",
       "integrity": "sha512-FsWboKkWdytGiXT5O1/R9j37YgcjO8MKHSUmWnIEjVaz0krHkplPnYi7mwdb+5+cs0toFNQb0HIrN7zONdIEWg==",
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.40.1",
         "@typescript-eslint/type-utils": "5.40.1",
@@ -20043,6 +20065,7 @@
       "version": "5.40.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.40.1.tgz",
       "integrity": "sha512-IK6x55va5w4YvXd4b3VrXQPldV9vQTxi5ov+g4pMANsXPTXOcfjx08CRR1Dfrcc51syPtXHF5bgLlMHYFrvQtg==",
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.40.1",
         "@typescript-eslint/types": "5.40.1",
@@ -20287,7 +20310,8 @@
     "acorn": {
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "peer": true
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -20365,6 +20389,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -20930,6 +20955,7 @@
       "version": "4.21.4",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
       "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001400",
         "electron-to-chromium": "^1.4.251",
@@ -21364,6 +21390,7 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -22045,6 +22072,7 @@
       "version": "8.25.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
       "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
+      "peer": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.3",
         "@humanwhocodes/config-array": "^0.10.5",
@@ -22412,6 +22440,7 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -23779,6 +23808,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
+      "peer": true,
       "requires": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -25352,11 +25382,6 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
     },
-    "lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
-    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -25509,6 +25534,7 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -26027,6 +26053,7 @@
       "version": "8.4.18",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
       "integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
+      "peer": true,
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -26609,6 +26636,7 @@
       "version": "6.0.10",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
       "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "peer": true,
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -26877,6 +26905,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -27011,6 +27040,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -27020,6 +27050,12 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "react-intersection-observer": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-10.0.3.tgz",
+      "integrity": "sha512-luICLMbs0zxTO/70Zy7K5jOXkABPEVSAF8T3FdZUlctsrIaPLmx8TZe2SSA+CY2HGWfz2INyNTnp82pxNNsShA==",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",
@@ -27036,20 +27072,11 @@
       "resolved": "https://registry.npmjs.org/react-multi-carousel/-/react-multi-carousel-2.8.2.tgz",
       "integrity": "sha512-M9Y7DfAp8bA/r6yexttU6RLA7uyppje4c0ELRuCHZWswH+u7nr0uVP6qHNPjc4XGOEY1MYFOb5nBg7JvoKutuQ=="
     },
-    "react-on-screen": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-on-screen/-/react-on-screen-2.1.1.tgz",
-      "integrity": "sha512-mV2Ntd61ncJ9nBsXF/p5Y6lMDGTTwXTGvHaal4b7O1eX3GwSwDXKAe7KKXTf/4Oc1BuYc7j5Sy0XdT89w/MjDA==",
-      "requires": {
-        "lodash.throttle": "^4.1.1",
-        "prop-types": "^15.6.0",
-        "shallowequal": "^1.0.2"
-      }
-    },
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
-      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
+      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
+      "peer": true
     },
     "react-scripts": {
       "version": "5.0.1",
@@ -27364,6 +27391,7 @@
       "version": "2.79.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
       "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "peer": true,
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -27631,11 +27659,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
-    },
-    "shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -28293,7 +28316,8 @@
     "type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "peer": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -28527,6 +28551,7 @@
       "version": "5.74.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
       "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -28591,6 +28616,7 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -28628,6 +28654,7 @@
       "version": "4.11.1",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.11.1.tgz",
       "integrity": "sha512-lILVz9tAUy1zGFwieuaQtYiadImb5M3d+H+L1zDYalYoDl0cksAB1UNyuE5MMWJrG6zR1tXkCP2fitl7yoUJiw==",
+      "peer": true,
       "requires": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -28664,6 +28691,7 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -28886,6 +28914,7 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "react-bootstrap": "^2.5.0",
     "react-bootstrap-icons": "^1.9.1",
     "react-dom": "^18.2.0",
+    "react-intersection-observer": "^10.0.3",
     "react-multi-carousel": "^2.8.2",
-    "react-on-screen": "^2.1.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/src/components/ContactMe.js
+++ b/src/components/ContactMe.js
@@ -1,31 +1,30 @@
 import "../assets/styles/Contact.css";
 import { Col, Container, Row } from "react-bootstrap";
-import TrackVisibility from "react-on-screen";
+import { useInView } from "react-intersection-observer";
 import ContactForm from "./ContactForm";
 
 import contactImage from "../assets/images/bitmoji/bitmoji-laptop-2.png";
 
 const ContactMe = () => {
+    const { ref, inView } = useInView({ triggerOnce: true });
+
     return (
         <section id="contact" className="contact">
             <Container>
                 <Row className="align-items-center">
                     <Col md={6} className="contact-image-container">
-                        <TrackVisibility partialVisibility once>
-                            {({ isVisible }) => (
-                                <div
-                                    className={`content animate__opacity-0 ${
-                                        isVisible && "animate__animated animate__fadeIn"
-                                    }`}
-                                >
-                                    <h2 className="hire-me nowrap">Wanna Hire Me?</h2>
-                                    <img
-                                        src={contactImage}
-                                        alt="Caricature of Miguel working at a laptop"
-                                    />
-                                </div>
-                            )}
-                        </TrackVisibility>
+                        <div
+                            ref={ref}
+                            className={`content animate__opacity-0 ${
+                                inView && "animate__animated animate__fadeIn"
+                            }`}
+                        >
+                            <h2 className="hire-me nowrap">Wanna Hire Me?</h2>
+                            <img
+                                src={contactImage}
+                                alt="Caricature of Miguel working at a laptop"
+                            />
+                        </div>
                     </Col>
                     <Col md={6} className="contact-form-container">
                         <h3 className="hire-me">Wanna Hire Me?</h3>

--- a/src/components/HeroContent.js
+++ b/src/components/HeroContent.js
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
 import { ArrowRightCircle } from 'react-bootstrap-icons';
-import TrackVisibility from 'react-on-screen';
+import { useInView } from 'react-intersection-observer';
 
 const HeroContent = () => {
+    const { ref, inView } = useInView({ triggerOnce: true });
     const [isTyping, setIsTyping] = useState(true);
     const [jobTitle, setJobTitle] = useState('');
     const [roleCount, setRoleCount] = useState(0);
@@ -47,55 +48,50 @@ const HeroContent = () => {
     };
 
     return (
-        <TrackVisibility once>
-            {({ isVisible }) => (
-                <div
-                    className={`content ${
-                        isVisible && 'animate__animated animate__fadeIn animate__slower'
-                    }`}
+        <div
+            ref={ref}
+            className={`content ${
+                inView && 'animate__animated animate__fadeIn animate__slower'
+            }`}
+        >
+            <span className="tagline">Thanks for dropping by</span>
+            <h1 className="intro-header">Hi, I'm Miguel!</h1>
+            <h1>
+                I'm a <span className="typing-text">{jobTitle}</span>
+            </h1>
+            <p className="copy">
+                My journey into programming began in 2005. I now have over{' '}
+                <a
+                    className="accent nowrap"
+                    href="https://www.linkedin.com/in/migueldot/"
+                    rel="noreferrer"
+                    target="_blank"
                 >
-                    <span className="tagline">Thanks for dropping by</span>
-                    <h1 className="intro-header">Hi, I'm Miguel!</h1>
-                    <h1>
-                        I'm a <span className="typing-text">{jobTitle}</span>
-                    </h1>
-                    <p className="copy">
-                        My journey into programming began in 2005. I now have over{' '}
-                        <a
-                            className="accent nowrap"
-                            href="https://www.linkedin.com/in/migueldot/"
-                            rel="noreferrer"
-                            target="_blank"
-                        >
-                            {yearsOfExp} years
-                        </a>{' '}
-                        of professional experience. I place equal importance on form and
-                        function, always considering the client's objective, the
-                        end-user's experience, and parsability for others who may work on
-                        the project. When I'm not writing code, I enjoy making music and
-                        learning{' '}
-                        <a
-                            className="accent nowrap"
-                            href="//www.duolingo.com/profile/MiguelDotL"
-                            rel="noreferrer"
-                            target="_blank"
-                        >
-                            new languages
-                        </a>
-                        .
-                    </p>
-                    <button
-                        className="hero-contact-button"
-                        onClick={() =>
-                            document.getElementById('contact').scrollIntoView()
-                        }
-                    >
-                        Let's Chat
-                        <ArrowRightCircle size={25} />
-                    </button>
-                </div>
-            )}
-        </TrackVisibility>
+                    {yearsOfExp} years
+                </a>{' '}
+                of professional experience. I place equal importance on form and
+                function, always considering the client's objective, the
+                end-user's experience, and parsability for others who may work on
+                the project. When I'm not writing code, I enjoy making music and
+                learning{' '}
+                <a
+                    className="accent nowrap"
+                    href="//www.duolingo.com/profile/MiguelDotL"
+                    rel="noreferrer"
+                    target="_blank"
+                >
+                    new languages
+                </a>
+                .
+            </p>
+            <button
+                className="hero-contact-button"
+                onClick={() => document.getElementById('contact').scrollIntoView()}
+            >
+                Let's Chat
+                <ArrowRightCircle size={25} />
+            </button>
+        </div>
     );
 };
 

--- a/src/components/Projects.js
+++ b/src/components/Projects.js
@@ -1,7 +1,7 @@
 import "../assets/styles/Projects.css";
 import { Col, Container, Row, Nav, Tab } from "react-bootstrap";
+import { useInView } from "react-intersection-observer";
 import ProjectList from "./ProjectList";
-import TrackVisibility from "react-on-screen";
 
 import generalProvision from "../assets/images/projects/general-provision-512.png";
 import trimAgency from "../assets/images/projects/trim-agency-512.png";
@@ -52,6 +52,8 @@ const clientProjects = [
 ];
 
 const Projects = () => {
+    const { ref, inView } = useInView({ triggerOnce: true });
+
     return (
         <section id="projects" className="projects">
             <img
@@ -62,14 +64,13 @@ const Projects = () => {
             <Container>
                 <Row>
                     <Col>
-                        <TrackVisibility partialVisibility once>
-                            {({ isVisible }) => (
-                                <div
-                                    className={`content animate__opacity-0 ${
-                                        isVisible &&
-                                        "animate__animated animate__fadeIn animate__slower"
-                                    }`}
-                                >
+                        <div
+                            ref={ref}
+                            className={`content animate__opacity-0 ${
+                                inView &&
+                                "animate__animated animate__fadeIn animate__slower"
+                            }`}
+                        >
                                     <h2>Projects</h2>
                                     <p className="copy">
                                         Over the course of my career, I have had the
@@ -149,9 +150,7 @@ const Projects = () => {
                                             </Tab.Pane>
                                         </Tab.Content>
                                     </Tab.Container>
-                                </div> // .content
-                            )}
-                        </TrackVisibility>
+                                </div>
                     </Col>
                 </Row>
             </Container>

--- a/src/components/Skills.js
+++ b/src/components/Skills.js
@@ -1,11 +1,13 @@
 import "../assets/styles/Skills.css";
 import { Container, Row } from "react-bootstrap";
-import TrackVisibility from "react-on-screen";
+import { useInView } from "react-intersection-observer";
 import "react-multi-carousel/lib/styles.css";
 import colorPop from "../assets/images/backgrounds/color-pop.png";
 import SkillsCarousel from "./SkillsCarousel";
 
 const Skills = () => {
+    const { ref, inView } = useInView({ triggerOnce: true });
+
     return (
         <section id="skills" className="skills">
             <img
@@ -16,27 +18,23 @@ const Skills = () => {
             <Container>
                 <Row>
                     <div className="skills-content">
-                        <TrackVisibility partialVisibility once>
-                            {({ isVisible }) => (
-                                <div
-                                    className={`animate__opacity-0 ${
-                                        isVisible &&
-                                        "animate__animated animate__fadeIn animate__slower"
-                                    }`}
-                                >
-                                    <h2>Skills</h2>
-                                    <p className="copy">
-                                        I love trying out new technologies, but I am well
-                                        versed in building projects with standard HTML,
-                                        CSS, Vanilla JS, and PHP. My professional
-                                        experience, and a never-ending quest for
-                                        knowledge, has led me to work in several libraries
-                                        and frameworks, like Ruby on Rails, React,
-                                        Angular, and jQuery.
-                                    </p>
-                                </div>
-                            )}
-                        </TrackVisibility>
+                        <div
+                            ref={ref}
+                            className={`animate__opacity-0 ${
+                                inView &&
+                                "animate__animated animate__fadeIn animate__slower"
+                            }`}
+                        >
+                            <h2>Skills</h2>
+                            <p className="copy">
+                                I love trying out new technologies, but I am well
+                                versed in building projects with standard HTML, CSS,
+                                Vanilla JS, and PHP. My professional experience, and a
+                                never-ending quest for knowledge, has led me to work
+                                in several libraries and frameworks, like Ruby on
+                                Rails, React, Angular, and jQuery.
+                            </p>
+                        </div>
                         <SkillsCarousel />
                     </div>
                 </Row>


### PR DESCRIPTION
## Summary

Swap visibility-detection library to unblock Vite migration (#15).

### Why

`react-on-screen` was last updated in 2019. It's not ESM-clean and is a likely breaker for the Vite production build. `react-intersection-observer` is actively maintained, uses the native Intersection Observer API, and has ~3.5M weekly downloads.

### Changes

| File | Change |
|---|---|
| `package.json` / lock | swap `react-on-screen` for `react-intersection-observer@10.0.3` |
| `HeroContent.js` | replace `<TrackVisibility>` render-prop with `useInView()` hook |
| `Skills.js` | same |
| `Projects.js` | same (note: indentation is now over-deep; cosmetic, will clean up in a follow-up) |
| `ContactMe.js` | same |

### Migration pattern

```js
// Before
<TrackVisibility partialVisibility once>
    {({ isVisible }) => <div className={isVisible && 'fade-in'}>...</div>}
</TrackVisibility>

// After
const { ref, inView } = useInView({ triggerOnce: true });
return <div ref={ref} className={inView && 'fade-in'}>...</div>;
```

## Test plan

- [x] `CI=true npm test -- --watchAll=false` — all 17 tests pass
- [ ] **Visual verify (Miguel):** fade-in animations on hero, skills, projects, and contact-me sections still trigger correctly when scrolling into view
- [ ] **Visual verify (Miguel):** typing animation in hero still cycles through Front-End / Back-End / Full-Stack Developer

Closes #29