### PR TITLE
feat: NavBar scroll spy — auto-update active link

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -58,6 +58,34 @@ const NavBar = () => {
         };
 
         window.addEventListener('scroll', onScroll);
+        return () => window.removeEventListener('scroll', onScroll);
+    }, []);
+
+    // Scroll spy: update activeLink as sections come into view
+    useEffect(() => {
+        const sectionIds = navLinks.map(({ name }) => name);
+        const sections = sectionIds
+            .map((id) => document.getElementById(id))
+            .filter(Boolean);
+
+        if (sections.length === 0) return;
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                const mostVisible = entries
+                    .filter((entry) => entry.isIntersecting)
+                    .sort(
+                        (a, b) => b.intersectionRatio - a.intersectionRatio
+                    )[0];
+                if (mostVisible) {
+                    setActiveLink(mostVisible.target.id);
+                }
+            },
+            { threshold: [0.25, 0.5, 0.75] }
+        );
+
+        sections.forEach((section) => observer.observe(section));
+        return () => observer.disconnect();
     }, []);
 
     const handleToggle = () => {


### PR DESCRIPTION
## Summary

NavBar's bold/active link now updates as the user scrolls (scroll spy pattern), not just on click.

Implementation: `IntersectionObserver` watching the four section ids (`home`, `skills`, `projects`, `contact`). The section with the highest visibility ratio drives the active link state.

Click handler still works the same way (sets active immediately, smooth-scrolls to the target).

## Test plan

- [x] `CI=true npm test -- --watchAll=false` — 17/17 pass
- [ ] Visual: scroll through page — bold highlight on Home → Skills → Projects → Contact tracks scroll position
- [ ] Click any nav link — still navigates and highlights as before

Closes #53