### PR TITLE
fix: NavBar scroll-spy oscillates between sections (#57)

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -61,31 +61,29 @@ const NavBar = () => {
         return () => window.removeEventListener('scroll', onScroll);
     }, []);
 
-    // Scroll spy: update activeLink as sections come into view
+    // Scroll spy: active link = last section whose top edge is at or above the trigger line.
+    // Monotonic — won't oscillate as sections enter/exit the viewport.
     useEffect(() => {
         const sectionIds = navLinks.map(({ name }) => name);
-        const sections = sectionIds
-            .map((id) => document.getElementById(id))
-            .filter(Boolean);
 
-        if (sections.length === 0) return;
+        const onScroll = () => {
+            const triggerY = 100;
+            const sections = sectionIds
+                .map((id) => document.getElementById(id))
+                .filter(Boolean);
 
-        const observer = new IntersectionObserver(
-            (entries) => {
-                const mostVisible = entries
-                    .filter((entry) => entry.isIntersecting)
-                    .sort(
-                        (a, b) => b.intersectionRatio - a.intersectionRatio
-                    )[0];
-                if (mostVisible) {
-                    setActiveLink(mostVisible.target.id);
+            let current = sectionIds[0];
+            for (const section of sections) {
+                if (section.getBoundingClientRect().top <= triggerY) {
+                    current = section.id;
                 }
-            },
-            { threshold: [0.25, 0.5, 0.75] }
-        );
+            }
+            setActiveLink(current);
+        };
 
-        sections.forEach((section) => observer.observe(section));
-        return () => observer.disconnect();
+        onScroll();
+        window.addEventListener('scroll', onScroll, { passive: true });
+        return () => window.removeEventListener('scroll', onScroll);
     }, []);
 
     const handleToggle = () => {


### PR DESCRIPTION
Closes #57. Follows up on #53.

## Summary

- Replace IntersectionObserver "highest intersectionRatio" comparison with a monotonic trigger-line scroll handler.
- Active link = last section whose top edge is at or above 100px below the viewport top.
- Uses `getBoundingClientRect().top` (viewport-relative — no `offsetParent` ambiguity).

## Why the old approach was unstable

`intersectionRatio` is section-relative, not viewport-relative:
- Short sections (Skills) hit ratio=1.0 the moment they're fully visible.
- Tall sections (Hero) cap out around 0.5–0.7 because they exceed the viewport.
- Result: Skills won the comparison even when Hero dominated the screen, and the active link oscillated between adjacent sections as ratios fluctuated during scroll.

## Test plan

- [ ] Load `/#home` → Home is active, Hero fully visible
- [ ] Scroll to Skills card centered → Skills active when Skills section's top crosses ~100px from viewport top
- [ ] Continue through Projects, Contact → each lights up at the correct boundary
- [ ] Scroll back up → reverses cleanly through the same boundaries
- [ ] No oscillation/back-and-forth between adjacent sections at any scroll position