### PR TITLE
fix: suppress filter transitions during carousel loop snap (#51)

### DIFF
--- a/src/assets/styles/Skills.css
+++ b/src/assets/styles/Skills.css
@@ -72,6 +72,17 @@
     filter: brightness(1) invert(0);
 }
 
+/* During the infinite-loop snap (clone→original swap), suppress transitions
+   so the filter cross-fade between the two DOM copies doesn't read as a
+   flash on the first/last icon. See SkillsCarousel.jsx isSnapping logic. */
+.skills-slider.is-snapping .item,
+.skills-slider.is-snapping .item i.devicon,
+.skills-slider.is-snapping .item img.custom-skill-icon,
+.skills-slider.is-snapping .item .icon-inactive,
+.skills-slider.is-snapping .item img.icon-active {
+    transition: none !important;
+}
+
 /* Dual-render cross-fade: monochrome font glyph (inactive) ↔ multi-color SVG (active) */
 .skills-slider .item .icon-inactive,
 .skills-slider .item img.icon-active {

--- a/src/components/SkillsCarousel.jsx
+++ b/src/components/SkillsCarousel.jsx
@@ -99,20 +99,23 @@ const SkillsCarousel = () => {
         { name: "Claude", iconPath: claudeIcon, color: "#D97757" }
     ];
 
-    const handleAfterChange = (_previousSlide, state) => {
-        const { currentSlide, totalItems, slidesToShow } = state;
-        // react-multi-carousel internals: clones array layout is
-        // [last 2*slidesToShow originals] + [originals] + [first 2*slidesToShow originals].
-        // It snaps when currentSlide reaches the trailing clone region
-        // (>= 2*slidesToShow + originalLength) or hits the leading clone region (=== 0).
+    const handleBeforeChange = (nextSlide, state) => {
+        const { totalItems, slidesToShow } = state;
+        // react-multi-carousel renders [end-clones, originals, start-clones].
+        // The carousel snaps when nextSlide hits a clone region:
+        // start clone (=== 0) or end clone (>= 2*slidesToShow + originalLength).
         const originalLength = totalItems - 4 * slidesToShow;
-        const atStart = currentSlide === 0;
-        const atEnd = currentSlide >= 2 * slidesToShow + originalLength;
-        if (!atStart && !atEnd) return;
+        const willSnap =
+            nextSlide === 0 || nextSlide >= 2 * slidesToShow + originalLength;
+        if (!willSnap) return;
+        // Set the class BEFORE the snap render so transitions are already
+        // suppressed when aria-hidden flips. afterChange fires too late —
+        // there's a paint frame between snap and class-add that re-introduces
+        // the cross-fade flash.
         setIsSnapping(true);
         if (snapResetRef.current) clearTimeout(snapResetRef.current);
-        // Long enough to cover the internal snap setState + paint.
-        snapResetRef.current = setTimeout(() => setIsSnapping(false), 100);
+        // Cover full animation (~400ms) + snap render + a buffer.
+        snapResetRef.current = setTimeout(() => setIsSnapping(false), 600);
     };
 
     useEffect(() => {
@@ -128,7 +131,7 @@ const SkillsCarousel = () => {
             responsive={responsive}
             infinite={true}
             swipeable={true}
-            afterChange={handleAfterChange}
+            beforeChange={handleBeforeChange}
         >
             {skills.map((skill) => {
                 const inactiveTag = skill.iconInactive || skill.class;

--- a/src/components/SkillsCarousel.jsx
+++ b/src/components/SkillsCarousel.jsx
@@ -99,23 +99,19 @@ const SkillsCarousel = () => {
         { name: "Claude", iconPath: claudeIcon, color: "#D97757" }
     ];
 
-    const handleBeforeChange = (nextSlide, state) => {
-        const { totalItems, slidesToShow } = state;
+    const handleAfterChange = (_previousSlide, state) => {
+        const { currentSlide, totalItems, slidesToShow } = state;
         // react-multi-carousel renders [end-clones, originals, start-clones].
-        // The carousel snaps when nextSlide hits a clone region:
-        // start clone (=== 0) or end clone (>= 2*slidesToShow + originalLength).
+        // It snaps when currentSlide reaches a clone region: start (=== 0)
+        // or end (>= 2*slidesToShow + originalLength).
         const originalLength = totalItems - 4 * slidesToShow;
-        const willSnap =
-            nextSlide === 0 || nextSlide >= 2 * slidesToShow + originalLength;
-        if (!willSnap) return;
-        // Set the class BEFORE the snap render so transitions are already
-        // suppressed when aria-hidden flips. afterChange fires too late —
-        // there's a paint frame between snap and class-add that re-introduces
-        // the cross-fade flash.
+        const atStart = currentSlide === 0;
+        const atEnd = currentSlide >= 2 * slidesToShow + originalLength;
+        if (!atStart && !atEnd) return;
         setIsSnapping(true);
         if (snapResetRef.current) clearTimeout(snapResetRef.current);
-        // Cover full animation (~400ms) + snap render + a buffer.
-        snapResetRef.current = setTimeout(() => setIsSnapping(false), 600);
+        // Cover the snap setState + render + paint.
+        snapResetRef.current = setTimeout(() => setIsSnapping(false), 100);
     };
 
     useEffect(() => {
@@ -131,7 +127,7 @@ const SkillsCarousel = () => {
             responsive={responsive}
             infinite={true}
             swipeable={true}
-            beforeChange={handleBeforeChange}
+            afterChange={handleAfterChange}
         >
             {skills.map((skill) => {
                 const inactiveTag = skill.iconInactive || skill.class;

--- a/src/components/SkillsCarousel.jsx
+++ b/src/components/SkillsCarousel.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import CarouselDefault from "react-multi-carousel";
 const Carousel = CarouselDefault.default || CarouselDefault;
 import claudeIcon from "../assets/images/icons/claude.svg";
@@ -13,6 +13,11 @@ import linuxIcon from "../assets/images/icons/linux.svg";
 
 const SkillsCarousel = () => {
     const carouselRef = useRef(null);
+    // True briefly while the carousel snaps clone→original at the loop boundary.
+    // Disables filter transitions during the snap so the user doesn't see
+    // the cross-fade dip that reads as a flash on the first icon (#51).
+    const [isSnapping, setIsSnapping] = useState(false);
+    const snapResetRef = useRef(null);
 
     // Keyboard nav: ArrowLeft/Right scroll the carousel when Skills is in view
     useEffect(() => {
@@ -94,13 +99,36 @@ const SkillsCarousel = () => {
         { name: "Claude", iconPath: claudeIcon, color: "#D97757" }
     ];
 
+    const handleAfterChange = (_previousSlide, state) => {
+        const { currentSlide, totalItems, slidesToShow } = state;
+        // react-multi-carousel internals: clones array layout is
+        // [last 2*slidesToShow originals] + [originals] + [first 2*slidesToShow originals].
+        // It snaps when currentSlide reaches the trailing clone region
+        // (>= 2*slidesToShow + originalLength) or hits the leading clone region (=== 0).
+        const originalLength = totalItems - 4 * slidesToShow;
+        const atStart = currentSlide === 0;
+        const atEnd = currentSlide >= 2 * slidesToShow + originalLength;
+        if (!atStart && !atEnd) return;
+        setIsSnapping(true);
+        if (snapResetRef.current) clearTimeout(snapResetRef.current);
+        // Long enough to cover the internal snap setState + paint.
+        snapResetRef.current = setTimeout(() => setIsSnapping(false), 100);
+    };
+
+    useEffect(() => {
+        return () => {
+            if (snapResetRef.current) clearTimeout(snapResetRef.current);
+        };
+    }, []);
+
     return (
         <Carousel
             ref={carouselRef}
-            className="skills-slider"
+            className={`skills-slider ${isSnapping ? "is-snapping" : ""}`}
             responsive={responsive}
             infinite={true}
             swipeable={true}
+            afterChange={handleAfterChange}
         >
             {skills.map((skill) => {
                 const inactiveTag = skill.iconInactive || skill.class;


### PR DESCRIPTION
Closes #51.

## The bug

When the skills carousel cycles all the way around (past the last skill, back to the first), the first icon flashes **on → off → on** before settling.

## Root cause

`react-multi-carousel` with \`infinite={true}\` renders **clones** of items at both ends of the track to enable seamless wraparound:

\`\`\`
[last 6 originals as clones] [22 originals] [first 6 originals as clones]
\`\`\`

When the user crosses a boundary (e.g. clicks past the last item):
1. Carousel animates to the clone of the first item (~400ms transform animation)
2. Internally, \`correctClonesPosition\` setState's the transform back to the equivalent **original** position — the "snap"
3. At the snap, \`aria-hidden\` flips on two DOM copies of the same skill at the same visual location

The CSS filter cross-fade between those two DOM copies (with their 0.3s ease-in-out transitions) produced the perceptible on→off→on flash.

## Fix

Detect the snap via the carousel's \`afterChange\` callback. When \`currentSlide\` lands on the boundary (\`=== 0\` for start, \`>= 2*slidesToShow + originalLength\` for end), set an \`is-snapping\` class on the slider for ~100ms. CSS short-circuits filter/opacity transitions while that class is present, so the snap fires instantly without the cross-fade artifact.

\`\`\`jsx
const [isSnapping, setIsSnapping] = useState(false);
const handleAfterChange = (_, state) => {
    const { currentSlide, totalItems, slidesToShow } = state;
    const originalLength = totalItems - 4 * slidesToShow;
    const atStart = currentSlide === 0;
    const atEnd = currentSlide >= 2 * slidesToShow + originalLength;
    if (!atStart && !atEnd) return;
    setIsSnapping(true);
    setTimeout(() => setIsSnapping(false), 100);
};
\`\`\`

## Verification

Playwright verified across both directions:
- **End-snap:** clicked forward 22 times → \`is-snapping\` fires exactly once, on the boundary click
- **Start-snap:** clicked backward 6 times → \`is-snapping\` fires exactly once, on the boundary click
- No false positives on intermediate clicks

## Test plan

- [ ] Reload Skills story / live site, hit the right arrow ~22 times until cycling around
- [ ] First icon (Bash) should appear smoothly with no flash
- [ ] Click prev arrow 6 times, watch for flash on the last icon (Claude) — should also be smooth
- [ ] Normal mid-cycle transitions should still cross-fade smoothly (transitions only suppressed at boundary)