### PR TITLE
fix: update index.html script to point at index.tsx

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,6 @@
     <body>
         <noscript>You need to enable JavaScript to run this app.</noscript>
         <div id="root"></div>
-        <script type="module" src="/src/index.jsx"></script>
+        <script type="module" src="/src/index.tsx"></script>
     </body>
 </html>


### PR DESCRIPTION
Follow-up to #24. The TypeScript migration renamed `src/index.jsx` → `src/index.tsx` but missed updating the `<script>` reference in `index.html`. Dev server returned 404 on the old path. Single-line fix.

## Test plan
- [ ] `npm run dev` → no 404 on entry script
- [ ] Site renders