### PR TITLE
feat: env-var the contact form endpoint (#22)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Form submission endpoint (full URL)
+VITE_FORM_ENDPOINT=https://getform.io/f/your-form-id-here

--- a/src/apis/getForm.ts
+++ b/src/apis/getForm.ts
@@ -1,9 +1,6 @@
 import axios from "axios";
 
-const baseURL = "https://getform.io";
-
 export default axios.create({
-    baseURL,
     headers: {
         Accept: "application/json"
     }

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -45,7 +45,7 @@ const ContactForm = () => {
         if (loading) return;
         setLoading(true);
 
-        const formEndpoint = "f/fc61ece9-9e62-44b7-8e77-a71d19cb1697";
+        const formEndpoint = import.meta.env.VITE_FORM_ENDPOINT;
 
         getForm
             .post(formEndpoint, formValues)

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+    readonly VITE_FORM_ENDPOINT: string;
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary

- Moves the hardcoded GetForm URL out of `ContactForm.tsx` into `VITE_FORM_ENDPOINT`
- Drops `baseURL` from `apis/getForm.ts` — the env var holds the full URL
- Adds `.env.example` (committed) + types the var in a new `src/vite-env.d.ts`
- Sets up the #25 Web3Forms swap (just change the env value, no code change needed)

## Files

- `.env.example` *(new)* — placeholder `VITE_FORM_ENDPOINT=https://getform.io/f/your-form-id-here`
- `src/vite-env.d.ts` *(new)* — types `VITE_FORM_ENDPOINT` as `string`
- `src/apis/getForm.ts` — removed `baseURL`
- `src/components/ContactForm.tsx:48` — reads `import.meta.env.VITE_FORM_ENDPOINT`

## Test plan

- [x] `tsc --noEmit` clean
- [x] Vitest 33/33 passing
- [x] `npm run build` succeeds
- [x] URL inlined into prod bundle (`grep` confirmed in `dist/assets/index-*.js`)
- [ ] Optional: live submit on dev server to verify the email lands

## Closes

#22