### PR TITLE
feat: swap GetForm → Web3Forms with success/error animations (#25)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,8 @@
-# Form submission endpoint (full URL)
-VITE_FORM_ENDPOINT=https://getform.io/f/your-form-id-here
+# Web3Forms contact form config
+# Get your access key at https://web3forms.com (free tier: 250 submissions/month)
+VITE_FORM_ENDPOINT=https://api.web3forms.com/submit
+VITE_FORM_ACCESS_KEY=your-access-key-here
+
+# Dev-only submit mock — values: success | error | throw
+# When set, dev server shortcircuits the form submit (no real API call). Prod ignores.
+# VITE_MOCK_FORM=success

--- a/src/apis/getForm.ts
+++ b/src/apis/getForm.ts
@@ -1,7 +1,0 @@
-import axios from "axios";
-
-export default axios.create({
-    headers: {
-        Accept: "application/json"
-    }
-});

--- a/src/assets/styles/Contact.css
+++ b/src/assets/styles/Contact.css
@@ -88,6 +88,18 @@
     color: #fff;
 }
 
+.contact form input:user-invalid,
+.contact form textarea:user-invalid {
+    border-color: rgba(252, 165, 165, 0.7);
+    background: rgba(252, 165, 165, 0.08);
+}
+
+.contact form input:user-invalid:focus,
+.contact form textarea:user-invalid:focus {
+    background: rgba(255, 255, 255, 1);
+    color: var(--dark-grey);
+}
+
 .contact form input:focus::placeholder, .contact form textarea:focus::placeholder {
     color: var(--dark-grey);
     opacity: 0.8;
@@ -102,6 +114,116 @@
 
 .contact form .form-status-message {
     margin: 2em 0 0 0;
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    width: 100%;
+}
+
+.contact form .form-status-message p {
+    margin: 0;
+}
+
+.contact form .form-status-message.success,
+.contact form .form-status-message.danger {
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 0.4em;
+    padding: 13px 26px;
+    animation: status-box-fade 0.35s ease-out 0.7s forwards;
+}
+
+.contact form .form-status-message.success {
+    color: #6ee7b7;
+}
+
+.contact form .form-status-message.danger {
+    color: #fca5a5;
+}
+
+@keyframes status-box-fade {
+    from {
+        background: transparent;
+        border-color: transparent;
+    }
+    to {
+        background: rgba(255, 255, 255, 0.1);
+        border-color: rgba(255, 255, 255, 0.5);
+    }
+}
+
+.contact form .form-status-message .envelope-icon {
+    display: inline-block;
+    font-size: 1.5em;
+    line-height: 1;
+    opacity: 0;
+    transform: translateX(-30px);
+    animation: envelope-slide 0.45s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+    z-index: 1;
+}
+
+.contact form .form-status-message .error-icon {
+    display: inline-block;
+    font-size: 1.5em;
+    line-height: 1;
+    opacity: 0;
+    animation: status-icon-fade 0.45s ease-out forwards;
+}
+
+.contact form .form-status-message.success p,
+.contact form .form-status-message.danger p {
+    opacity: 0;
+    animation: status-text-fade 0.3s ease-out 0.4s forwards;
+}
+
+@keyframes envelope-slide {
+    from {
+        opacity: 0;
+        transform: translateX(-30px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+@keyframes status-text-fade {
+    from {
+        opacity: 0;
+        transform: translateX(-8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+@keyframes status-icon-fade {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .contact form .form-status-message .envelope-icon,
+    .contact form .form-status-message .error-icon,
+    .contact form .form-status-message.success p,
+    .contact form .form-status-message.danger p,
+    .contact form .form-status-message.success,
+    .contact form .form-status-message.danger {
+        animation: none;
+        opacity: 1;
+        transform: none;
+    }
+
+    .contact form .form-status-message.success,
+    .contact form .form-status-message.danger {
+        background: rgba(255, 255, 255, 0.1);
+        border-color: rgba(255, 255, 255, 0.5);
+    }
 }
 
 .contact form button {
@@ -111,9 +233,29 @@
     font-size: 18px;
     font-weight: 700;
     padding: 14px 48px;
+    min-width: 11em;
     width: 100%;
     position: relative;
-    transition: 0.3s ease-in-out;
+    z-index: 2;
+    transition: opacity 0.3s ease-in-out, background-color 0.3s ease-in-out, color 0.3s ease-in-out;
+}
+
+.contact form button[disabled] {
+    cursor: not-allowed;
+}
+
+.contact form .submit-container.is-sent button[disabled] {
+    background-color: #d4d4d4;
+    color: #6b7280;
+}
+
+.contact form .submit-container.is-sent button[disabled]:hover {
+    color: #6b7280;
+}
+
+.contact form .submit-container.is-sent button[disabled]::before,
+.contact form .submit-container.is-sent button[disabled]:hover::before {
+    width: 0;
 }
 
 .contact form button span {
@@ -182,8 +324,12 @@
         margin: 0em;
     }
 
+}
+
+@media screen and (min-width:992px) {
     .contact form .submit-container {
         flex-direction: row;
+        align-items: center;
     }
 
     .contact form button {
@@ -192,5 +338,6 @@
 
     .contact form .form-status-message {
         margin: 0 0 0 2em;
+        flex: 1;
     }
 }

--- a/src/components/ContactForm.test.tsx
+++ b/src/components/ContactForm.test.tsx
@@ -1,12 +1,10 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
+import axios from 'axios';
 import ContactForm from './ContactForm';
-import getForm from '../apis/getForm';
 
-vi.mock('../apis/getForm', () => ({
-    default: { post: vi.fn() }
-}));
+vi.mock('axios');
 
 describe('ContactForm', () => {
     beforeEach(() => {
@@ -36,25 +34,36 @@ describe('ContactForm', () => {
         expect(email).toHaveValue('test@example.com');
     });
 
-    test('submits form with values and shows success message', async () => {
-        vi.mocked(getForm.post).mockResolvedValueOnce({ status: 200, data: { success: true } });
+    const fillAllRequiredFields = async (user: ReturnType<typeof userEvent.setup>) => {
+        await user.type(screen.getByPlaceholderText(/First Name/i), 'Miguel');
+        await user.type(screen.getByPlaceholderText(/Last Name/i), 'Lozano');
+        await user.type(screen.getByPlaceholderText(/Email Address/i), 'a@b.com');
+        await user.type(screen.getByPlaceholderText(/Phone Number/i), '5555550100');
+        await user.type(screen.getByPlaceholderText(/Message/i), 'Hello!');
+    };
+
+    test('submits Web3Forms payload and shows success message', async () => {
+        vi.mocked(axios.post).mockResolvedValueOnce({
+            status: 200,
+            data: { success: true, message: 'Email sent' }
+        });
 
         const user = userEvent.setup();
         render(<ContactForm />);
 
-        await user.type(screen.getByPlaceholderText(/First Name/i), 'Miguel');
-        await user.type(screen.getByPlaceholderText(/Email Address/i), 'a@b.com');
-        await user.type(screen.getByPlaceholderText(/Message/i), 'Hello!');
+        await fillAllRequiredFields(user);
         await user.click(screen.getByRole('button', { name: /send/i }));
 
         await waitFor(() => {
-            expect(vi.mocked(getForm.post)).toHaveBeenCalledTimes(1);
+            expect(vi.mocked(axios.post)).toHaveBeenCalledTimes(1);
         });
 
-        const [, payload] = vi.mocked(getForm.post).mock.calls[0] as [string, Record<string, string>];
+        const [, payload] = vi.mocked(axios.post).mock.calls[0] as [string, Record<string, string>];
+        expect(payload.access_key).toBeDefined();
         expect(payload.firstName).toBe('Miguel');
         expect(payload.email).toBe('a@b.com');
         expect(payload.message).toBe('Hello!');
+        expect(payload.botcheck).toBe('');
 
         await waitFor(() => {
             expect(screen.getByText(/Thanks for reaching out/i)).toBeInTheDocument();
@@ -62,16 +71,42 @@ describe('ContactForm', () => {
     });
 
     test('shows error message when submission fails', async () => {
-        vi.mocked(getForm.post).mockRejectedValueOnce(new Error('Network down'));
+        vi.mocked(axios.post).mockRejectedValueOnce(new Error('Network down'));
 
         const user = userEvent.setup();
         render(<ContactForm />);
 
-        await user.type(screen.getByPlaceholderText(/First Name/i), 'Miguel');
+        await fillAllRequiredFields(user);
         await user.click(screen.getByRole('button', { name: /send/i }));
 
         await waitFor(() => {
-            expect(screen.getByText(/Oops! Network down/i)).toBeInTheDocument();
+            expect(screen.getByText(/Oops! Request Failed/i)).toBeInTheDocument();
         });
+    });
+
+    test('shows error when Web3Forms returns success: false', async () => {
+        vi.mocked(axios.post).mockResolvedValueOnce({
+            status: 200,
+            data: { success: false, message: 'Spam detected' }
+        });
+
+        const user = userEvent.setup();
+        render(<ContactForm />);
+
+        await fillAllRequiredFields(user);
+        await user.click(screen.getByRole('button', { name: /send/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText(/Oops! Request Failed/i)).toBeInTheDocument();
+        });
+    });
+
+    test('blocks submit when required fields are empty', async () => {
+        const user = userEvent.setup();
+        render(<ContactForm />);
+
+        await user.click(screen.getByRole('button', { name: /send/i }));
+
+        expect(vi.mocked(axios.post)).not.toHaveBeenCalled();
     });
 });

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { ChangeEvent, FormEvent } from "react";
+import axios from "axios";
 import { Col, Row } from "react-bootstrap";
-import getForm from "../apis/getForm";
 
 type FormStatus = {
     status: number | null;
@@ -10,16 +10,37 @@ type FormStatus = {
     message: string;
 };
 
+type SubmitResponse = { status: number; data: { success: boolean; message: string } };
+
+const submitForm = async (
+    payload: Record<string, string>
+): Promise<SubmitResponse> => {
+    const mock = import.meta.env.VITE_MOCK_FORM;
+    const isMockable = import.meta.env.DEV && import.meta.env.MODE !== "test";
+    if (isMockable && mock) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        if (mock === "error") {
+            return { status: 200, data: { success: false, message: "[MOCK] Spam detected" } };
+        }
+        if (mock === "throw") {
+            throw new Error("[MOCK] Request failed with status code 429");
+        }
+        return { status: 200, data: { success: true, message: "[MOCK] Email sent" } };
+    }
+    return axios.post(import.meta.env.VITE_FORM_ENDPOINT, payload);
+};
+
 const ContactForm = () => {
     const initialValues = {
         firstName: "",
         lastName: "",
         email: "",
         phone: "",
-        message: ""
+        message: "",
+        botcheck: ""
     };
     const [formValues, setFormValues] = useState(initialValues);
-    const [buttonText, setButtonText] = useState("send");
+    const [buttonText, setButtonText] = useState("Send");
     const [loading, setLoading] = useState(false);
     const [formStatus, setFormStatus] = useState<FormStatus>({
         status: null,
@@ -27,6 +48,8 @@ const ContactForm = () => {
         error: null,
         message: ""
     });
+
+    const isSent = formStatus.success === true;
 
     const onFormChange = () => {
         return (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -41,47 +64,86 @@ const ContactForm = () => {
 
     const onFormSubmit = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
+        if (loading || isSent) return;
         setButtonText("Sending...");
-        if (loading) return;
         setLoading(true);
 
-        const formEndpoint = import.meta.env.VITE_FORM_ENDPOINT;
+        const payload = {
+            access_key: import.meta.env.VITE_FORM_ACCESS_KEY,
+            subject: `Portfolio contact from ${formValues.firstName} ${formValues.lastName}`.trim(),
+            ...formValues
+        };
 
-        getForm
-            .post(formEndpoint, formValues)
+        submitForm(payload)
             .then((response) => {
-                setFormStatus({
-                    success: response.data.success,
-                    status: response.status,
-                    error: null,
-                    message: "Thanks for reaching out, I'll be in touch!"
-                });
-                setFormValues(initialValues);
+                if (response.data.success) {
+                    setFormStatus({
+                        success: true,
+                        status: response.status,
+                        error: null,
+                        message: "Thanks for reaching out, I'll be in touch!"
+                    });
+                    setFormValues(initialValues);
+                    setButtonText("Sent ✓");
+                } else {
+                    setFormStatus({
+                        success: false,
+                        status: response.status,
+                        error: response.data.message ?? "Submission failed",
+                        message: "Oops! Request Failed. Please try again soon"
+                    });
+                    setButtonText("Send");
+                }
                 setLoading(false);
-                setButtonText("Send");
             })
             .catch((error: Error) => {
                 setFormStatus({
                     ...formStatus,
                     error: error.message,
-                    message: `Oops! ${error.message} - Please try again later.`
+                    message: "Oops! Request Failed. Please try again soon"
                 });
                 setLoading(false);
                 setButtonText("Send");
             });
     };
 
+    const containerClasses = [
+        "submit-container",
+        "px-1",
+        isSent ? "is-sent" : ""
+    ]
+        .filter(Boolean)
+        .join(" ");
+
+    const statusClass =
+        formStatus.success === true
+            ? "success"
+            : formStatus.success === false
+            ? "danger"
+            : "";
+
     return (
-        <form encType="multipart/form-data" onSubmit={onFormSubmit}>
+        <form onSubmit={onFormSubmit}>
+            <input
+                type="text"
+                name="botcheck"
+                value={formValues.botcheck}
+                onChange={onFormChange()}
+                style={{ display: "none" }}
+                tabIndex={-1}
+                autoComplete="off"
+                aria-hidden="true"
+            />
             <Row>
                 <Col className="px-1" sm={6}>
                     <input
                         type="text"
                         name="firstName"
                         value={formValues.firstName}
-                        placeholder="First Name"
-                        aria-label="First Name"
+                        placeholder="First Name *"
+                        aria-label="First Name (required)"
                         onChange={onFormChange()}
+                        required
                     />
                 </Col>
                 <Col className="px-1" sm={6}>
@@ -89,9 +151,10 @@ const ContactForm = () => {
                         type="text"
                         name="lastName"
                         value={formValues.lastName}
-                        placeholder="Last Name"
-                        aria-label="Last Name"
+                        placeholder="Last Name *"
+                        aria-label="Last Name (required)"
                         onChange={onFormChange()}
+                        required
                     />
                 </Col>
             </Row>
@@ -101,9 +164,10 @@ const ContactForm = () => {
                         type="email"
                         name="email"
                         value={formValues.email}
-                        placeholder="Email Address"
-                        aria-label="Email Address"
+                        placeholder="Email Address *"
+                        aria-label="Email Address (required)"
                         onChange={onFormChange()}
+                        required
                     />
                 </Col>
                 <Col className="px-1" sm={6}>
@@ -122,20 +186,34 @@ const ContactForm = () => {
                         name="message"
                         rows={6}
                         value={formValues.message}
-                        placeholder="Message"
-                        aria-label="Message"
+                        placeholder="Message *"
+                        aria-label="Message (required)"
                         onChange={onFormChange()}
+                        required
                     />
                 </Col>
-                <div className="submit-container px-1">
-                    <button type="submit">
+                <div className={containerClasses}>
+                    <button
+                        type="submit"
+                        disabled={loading || isSent}
+                    >
                         <span>{buttonText}</span>
                     </button>
                     <div
-                        className={`form-status-message ${
-                            formStatus.success ? "success" : "danger"
-                        }`}
+                        className={`form-status-message ${statusClass}`}
+                        role="status"
+                        aria-live="polite"
                     >
+                        {isSent && (
+                            <span className="envelope-icon" aria-hidden="true">
+                                {"\u{1F4E8}"}
+                            </span>
+                        )}
+                        {formStatus.success === false && (
+                            <span className="error-icon" aria-hidden="true">
+                                {"\u{1F605}"}
+                            </span>
+                        )}
                         <p>{formStatus.message}</p>
                     </div>
                 </div>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,8 @@
 
 interface ImportMetaEnv {
     readonly VITE_FORM_ENDPOINT: string;
+    readonly VITE_FORM_ACCESS_KEY: string;
+    readonly VITE_MOCK_FORM?: "success" | "error" | "throw";
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

- Migrates contact form from GetForm to Web3Forms (250 free submissions/month, AWS-backed, public access keys per their docs)
- Staged success animation: envelope slides in → text fades in → box materializes around both
- Matching error animation: 😅 fades in (no slide) → text fades → box materializes
- Send button locks as \"Sent ✓\" on success (disabled, greyed)
- Honeypot \`botcheck\` field — Web3Forms auto-rejects when filled

## Validation

- 4 of 5 fields required (phone optional) — \" *\" suffix on required placeholders
- \`:user-invalid\` red-pink styling after first interaction
- Browser-native tooltips for empty/invalid (\"Please fill out this field\", email format)

## Layout

- Status box matches form-field styling (translucent bg, rounded border)
- Full-width on mobile/tablet (button + box stack); side-by-side on ≥992px
- Box right-edge aligns with form input fields above

## Dev tooling

- \`VITE_MOCK_FORM\` toggle: \`success\` | \`error\` | \`throw\` lets you exercise the success/error UI without burning API quota
- Gated on \`import.meta.env.DEV && MODE !== 'test'\` — prod ignores, tests bypass
- Verified: prod bundle has zero references to \`MOCK\` strings (dead-code eliminated)

## Cleanup

- Drops \`src/apis/getForm.ts\` — wrapper was empty after #22 \`baseURL\` removal

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] Vitest 35/35 (added blocks-on-empty-required-fields test)
- [x] \`npm run build\` succeeds
- [x] Mock code dead-code eliminated from prod bundle (\`grep MOCK dist\` → 0)
- [x] Live success path tested (real Web3Forms send → email landed)
- [x] Live error path tested (429 rate-limit triggered the error UI)
- [ ] Optional: end-to-end verify on prod build before deploy

## Closes

#25