### PR TITLE
feat: add Schema.org JSON-LD structured data (#36)

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,41 @@
         <link rel="apple-touch-icon" href="/logo192.png" />
         <link rel="manifest" href="/manifest.json" />
         <title>Miguel Lozano</title>
+        <script type="application/ld+json">
+            {
+                "@context": "https://schema.org",
+                "@type": "Person",
+                "name": "Miguel Lozano",
+                "jobTitle": "Full-Stack Developer",
+                "url": "https://migueldotl.github.io/",
+                "sameAs": [
+                    "https://github.com/MiguelDotL",
+                    "https://www.linkedin.com/in/migueldot/",
+                    "https://codepen.io/MiguelDotL",
+                    "https://www.npmjs.com/~migueldotl"
+                ]
+            }
+        </script>
+        <script type="application/ld+json">
+            {
+                "@context": "https://schema.org",
+                "@type": "WebSite",
+                "name": "Miguel Lozano — Portfolio",
+                "url": "https://migueldotl.github.io/"
+            }
+        </script>
+        <script type="application/ld+json">
+            {
+                "@context": "https://schema.org",
+                "@type": "ProfilePage",
+                "url": "https://migueldotl.github.io/",
+                "mainEntity": {
+                    "@type": "Person",
+                    "name": "Miguel Lozano",
+                    "url": "https://migueldotl.github.io/"
+                }
+            }
+        </script>
     </head>
     <body>
         <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## Summary

- Adds three JSON-LD schemas to \`index.html\` head: \`Person\`, \`WebSite\`, \`ProfilePage\`
- All URLs sourced from existing components (NavBar / Footer / SocialIcons)
- Job title: \"Full-Stack Developer\" (most encompassing of Hero typing options)
- Zero visual change — pure metadata

## Schemas

- **Person** — name, jobTitle, url, sameAs (GitHub, LinkedIn, CodePen, NPM)
- **WebSite** — name + url
- **ProfilePage** — wraps Person as the page's main entity

## Test plan

- [x] \`npm run build\` succeeds
- [x] \`grep application/ld+json dist/index.html\` returns 3 (all schemas inlined)
- [x] All social URLs present in dist
- [ ] Post-deploy: validate via [Google Rich Results Test](https://search.google.com/test/rich-results)

## Closes

#36