### PR TITLE
feat: Playwright E2E + Chromatic visual regression (closes #34, #35)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ VITE_FORM_ACCESS_KEY=your-access-key-here
 # Dev-only submit mock — values: success | error | throw
 # When set, dev server shortcircuits the form submit (no real API call). Prod ignores.
 # VITE_MOCK_FORM=success
+
+# Chromatic visual regression token — get from https://www.chromatic.com → project Manage page
+# CHROMATIC_PROJECT_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,12 @@
 /dist
 /storybook-static
 
+# Playwright
+playwright-report/
+test-results/
+blob-report/
+playwright/.cache/
+
 # environment
 .env
 .env.*

--- a/chromatic.config.json
+++ b/chromatic.config.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://www.chromatic.com/config-file.schema.json",
+    "buildScriptName": "build-storybook",
+    "onlyChanged": true,
+    "exitOnceUploaded": true,
+    "skip": "main"
+}

--- a/e2e/contact-form.spec.ts
+++ b/e2e/contact-form.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('contact form', () => {
+    test('happy path: fills + submits + shows success', async ({ page }) => {
+        await page.goto('/#contact');
+        await page.getByLabel('First Name (required)').fill('Test');
+        await page.getByLabel('Last Name (required)').fill('User');
+        await page.getByLabel('Email Address (required)').fill('test@example.com');
+        await page.getByLabel('Phone Number').fill('555-555-5555');
+        await page.getByLabel('Message (required)').fill('Hello from Playwright');
+
+        await page.getByRole('button', { name: /send/i }).click();
+
+        const status = page.getByRole('status');
+        await expect(status).toContainText(/Thanks for reaching out/i);
+        await expect(page.getByRole('button')).toContainText(/Sent/);
+    });
+
+    test('empty submit blocked by HTML5 validation', async ({ page }) => {
+        await page.goto('/#contact');
+        await page.getByRole('button', { name: /send/i }).click();
+        const firstName = page.getByLabel('First Name (required)');
+        const isInvalid = await firstName.evaluate(
+            (el) => (el as HTMLInputElement).validity.valueMissing
+        );
+        expect(isInvalid).toBe(true);
+    });
+});

--- a/e2e/featured-slider.spec.ts
+++ b/e2e/featured-slider.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('featured slider + lightbox', () => {
+    test('arrows advance the active dot', async ({ page }) => {
+        await page.goto('/#projects');
+        const slider = page
+            .locator('.featured-image-slider')
+            .filter({ has: page.locator('img[alt^="BCBS"]') })
+            .first();
+        await slider.scrollIntoViewIfNeeded();
+        await slider.hover();
+
+        const dots = slider.locator('.featured-image-slider__dot');
+        await expect(dots.nth(0)).toHaveAttribute('aria-selected', 'true');
+
+        await slider.locator('button[aria-label="Next image"]').first().click();
+        await expect(dots.nth(1)).toHaveAttribute('aria-selected', 'true');
+    });
+
+    test('clicking active slide opens lightbox; Escape dismisses', async ({ page }) => {
+        await page.goto('/#projects');
+        const slider = page
+            .locator('.featured-image-slider')
+            .filter({ has: page.locator('img[alt^="BCBS"]') })
+            .first();
+        await slider.scrollIntoViewIfNeeded();
+        await slider.hover();
+
+        await slider.locator('img.is-active').click();
+
+        const dialog = page.locator('[role="dialog"][aria-modal="true"]');
+        await expect(dialog).toBeVisible();
+
+        await page.keyboard.press('ArrowRight');
+        // Lightbox image should still be visible after navigating.
+        await expect(dialog.locator('img').first()).toBeVisible();
+
+        await page.keyboard.press('Escape');
+        await expect(dialog).toBeHidden();
+    });
+});

--- a/e2e/momentum-tabs.spec.ts
+++ b/e2e/momentum-tabs.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('MomentumTabs', () => {
+    test('switching tabs swaps content', async ({ page }) => {
+        await page.goto('/#projects');
+
+        const featuredTab = page.getByRole('tab', { name: 'Featured Projects' });
+        const clientTab = page.getByRole('tab', { name: 'Client Projects' });
+        const personalTab = page.getByRole('tab', { name: 'Personal Projects' });
+
+        await expect(featuredTab).toHaveAttribute('aria-selected', 'true');
+        await expect(page.getByText('BCBS NC — LiteHouse')).toBeVisible();
+
+        await clientTab.click();
+        await expect(clientTab).toHaveAttribute('aria-selected', 'true');
+        await expect(page.getByText('T R I M Agency')).toBeVisible();
+
+        await personalTab.click();
+        await expect(personalTab).toHaveAttribute('aria-selected', 'true');
+        await expect(page.getByText('Voicepool')).toBeVisible();
+    });
+
+    test('perimeter SVG present and aria-hidden', async ({ page }) => {
+        await page.goto('/#projects');
+        const perimeter = page.locator('.momentum-tabs__perimeter');
+        await expect(perimeter.first()).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    test('tabs realign after viewport resize', async ({ page }) => {
+        await page.setViewportSize({ width: 1280, height: 800 });
+        await page.goto('/#projects');
+        const activeTab = page.getByRole('tab', { selected: true });
+        await activeTab.scrollIntoViewIfNeeded();
+        const perimeter = page.locator('.momentum-tabs__perimeter').first();
+
+        const beforeBox = await perimeter.boundingBox();
+        const tabBoxBefore = await activeTab.boundingBox();
+
+        await page.setViewportSize({ width: 800, height: 800 });
+        // Allow layout + indicator transition to settle.
+        await page.waitForTimeout(700);
+        await page.setViewportSize({ width: 1280, height: 800 });
+        await page.waitForTimeout(700);
+
+        const afterBox = await perimeter.boundingBox();
+        const tabBoxAfter = await activeTab.boundingBox();
+
+        expect(beforeBox).not.toBeNull();
+        expect(afterBox).not.toBeNull();
+        expect(tabBoxBefore).not.toBeNull();
+        expect(tabBoxAfter).not.toBeNull();
+        // Perimeter should still hug the active tab (within a few pixels).
+        expect(Math.abs(afterBox!.x - tabBoxAfter!.x)).toBeLessThan(8);
+        expect(Math.abs(afterBox!.width - tabBoxAfter!.width)).toBeLessThan(12);
+    });
+});

--- a/e2e/momentum-tabs.spec.ts
+++ b/e2e/momentum-tabs.spec.ts
@@ -29,7 +29,8 @@ test.describe('MomentumTabs', () => {
     test('tabs realign after viewport resize', async ({ page }) => {
         await page.setViewportSize({ width: 1280, height: 800 });
         await page.goto('/#projects');
-        const activeTab = page.getByRole('tab', { selected: true });
+        const tabBar = page.locator('.momentum-tabs');
+        const activeTab = tabBar.locator('.momentum-tab.is-active').first();
         await activeTab.scrollIntoViewIfNeeded();
         const perimeter = page.locator('.momentum-tabs__perimeter').first();
 

--- a/e2e/skills-carousel.spec.ts
+++ b/e2e/skills-carousel.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+const TS_AFTER_OPACITY_SELECTOR =
+    '.skills-slider .react-multi-carousel-item.is-current i.devicon-typescript-plain';
+
+const getTsCurrentAfterOpacity = async (page: import('@playwright/test').Page) => {
+    return page.evaluate((sel) => {
+        const el = document.querySelector(sel);
+        if (!el) return null;
+        return window.getComputedStyle(el, '::after').opacity;
+    }, TS_AFTER_OPACITY_SELECTOR);
+};
+
+test.describe('Skills carousel', () => {
+    test('TS icon shows white background when centered, hides when not', async ({ page }) => {
+        await page.goto('/#skills');
+        await page.locator('#skills').scrollIntoViewIfNeeded();
+
+        const carousel = page.locator('.skills-slider');
+        await expect(carousel).toBeVisible();
+
+        // Press ArrowRight until the TS icon's `::after` reports opacity 1.
+        let opacity: string | null = null;
+        for (let i = 0; i < 25; i++) {
+            opacity = await getTsCurrentAfterOpacity(page);
+            if (opacity === '1') break;
+            await page.keyboard.press('ArrowRight');
+            await page.waitForTimeout(120);
+        }
+        expect(opacity).toBe('1');
+
+        // Press ArrowLeft a few times — TS icon should no longer be the centered one.
+        for (let i = 0; i < 6; i++) {
+            await page.keyboard.press('ArrowLeft');
+            await page.waitForTimeout(120);
+        }
+        const opacityAfter = await getTsCurrentAfterOpacity(page);
+        // Either the centered item no longer contains TS (selector returns null) or
+        // the ::after has faded to 0.
+        expect(opacityAfter === null || opacityAfter === '0').toBe(true);
+    });
+});

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('smoke', () => {
+    test('home page loads with expected title', async ({ page }) => {
+        await page.goto('/');
+        await expect(page).toHaveTitle(/Miguel/i);
+    });
+
+    const sections = ['home', 'skills', 'projects', 'contact'];
+    for (const id of sections) {
+        test(`nav anchor scrolls #${id} into view`, async ({ page }) => {
+            await page.goto('/');
+            const link = page.locator(`nav a[href="#${id}"]`).first();
+            await expect(link).toBeVisible();
+            await link.click();
+            const section = page.locator(`#${id}`);
+            await expect(section).toBeInViewport({ ratio: 0.1 });
+        });
+    }
+
+    test('footer renders with npm icon link', async ({ page }) => {
+        await page.goto('/');
+        const footer = page.locator('footer');
+        await expect(footer).toBeVisible();
+        await expect(footer.locator('a[href*="npmjs.com"]')).toBeVisible();
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/browser-playwright": "^4.1.5",
         "@vitest/coverage-v8": "^4.1.5",
+        "chromatic": "^16.6.3",
         "eslint": "^9.39.4",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -443,6 +444,30 @@
       },
       "peerDependencies": {
         "storybook": "^0.0.0-0 || ^10.1.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0"
+      }
+    },
+    "node_modules/@chromatic-com/storybook/node_modules/chromatic": {
+      "version": "13.3.5",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-13.3.5.tgz",
+      "integrity": "sha512-MzPhxpl838qJUo0A55osCF2ifwPbjcIPeElr1d4SHcjnHoIcg7l1syJDrAYK/a+PcCBrOGi06jPNpQAln5hWgw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "chroma": "dist/bin.js",
+        "chromatic": "dist/bin.js",
+        "chromatic-cli": "dist/bin.js"
+      },
+      "peerDependencies": {
+        "@chromatic-com/cypress": "^0.*.* || ^1.0.0",
+        "@chromatic-com/playwright": "^0.*.* || ^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@chromatic-com/cypress": {
+          "optional": true
+        },
+        "@chromatic-com/playwright": {
+          "optional": true
+        }
       }
     },
     "node_modules/@commitlint/cli": {
@@ -4738,25 +4763,32 @@
       }
     },
     "node_modules/chromatic": {
-      "version": "13.3.5",
-      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-13.3.5.tgz",
-      "integrity": "sha512-MzPhxpl838qJUo0A55osCF2ifwPbjcIPeElr1d4SHcjnHoIcg7l1syJDrAYK/a+PcCBrOGi06jPNpQAln5hWgw==",
+      "version": "16.6.3",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-16.6.3.tgz",
+      "integrity": "sha512-N9WCRuezqrxujRvgnAlE9XKxXcF6q2kowKH2Ba82FYkRc4xlY9g8r+ESEph9jLv500s43/9oDmB/kZ9r24BcgQ==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
       "bin": {
-        "chroma": "dist/bin.js",
-        "chromatic": "dist/bin.js",
-        "chromatic-cli": "dist/bin.js"
+        "chroma": "dist/bin.cjs",
+        "chromatic": "dist/bin.cjs",
+        "chromatic-cli": "dist/bin.cjs"
       },
       "peerDependencies": {
         "@chromatic-com/cypress": "^0.*.* || ^1.0.0",
-        "@chromatic-com/playwright": "^0.*.* || ^1.0.0"
+        "@chromatic-com/playwright": "^0.*.* || ^1.0.0",
+        "@chromatic-com/vitest": "^0.*.* || ^1.0.0"
       },
       "peerDependenciesMeta": {
         "@chromatic-com/cypress": {
           "optional": true
         },
         "@chromatic-com/playwright": {
+          "optional": true
+        },
+        "@chromatic-com/vitest": {
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@commitlint/cli": "^20.5.3",
         "@commitlint/config-conventional": "^20.5.3",
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.59.1",
         "@storybook/addon-a11y": "^10.3.6",
         "@storybook/addon-docs": "^10.3.6",
         "@storybook/addon-vitest": "^10.3.6",
@@ -2383,6 +2384,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     "test": "vitest run",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:headed": "playwright test --headed",
+    "e2e:install": "playwright install",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "prepare": "husky"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@commitlint/cli": "^20.5.3",
     "@commitlint/config-conventional": "^20.5.3",
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.59.1",
     "@storybook/addon-a11y": "^10.3.6",
     "@storybook/addon-docs": "^10.3.6",
     "@storybook/addon-vitest": "^10.3.6",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "e2e:ui": "playwright test --ui",
     "e2e:headed": "playwright test --headed",
     "e2e:install": "playwright install",
+    "chromatic": "chromatic --project-token=$CHROMATIC_PROJECT_TOKEN",
+    "chromatic:baseline": "chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --auto-accept-changes",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "prepare": "husky"
@@ -53,6 +55,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/browser-playwright": "^4.1.5",
     "@vitest/coverage-v8": "^4.1.5",
+    "chromatic": "^16.6.3",
     "eslint": "^9.39.4",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+    testDir: './e2e',
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 2 : 0,
+    reporter: 'html',
+    use: {
+        baseURL: 'http://localhost:3000',
+        trace: 'on-first-retry',
+        screenshot: 'only-on-failure'
+    },
+    projects: [
+        { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+        { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+        { name: 'webkit', use: { ...devices['Desktop Safari'] } }
+    ],
+    webServer: {
+        command: 'npm run dev',
+        url: 'http://localhost:3000',
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+        env: {
+            VITE_MOCK_FORM: 'success'
+        }
+    }
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -26,7 +26,8 @@ export default defineConfig({
         globals: true,
         environment: "jsdom",
         setupFiles: "./src/setupTests.js",
-        css: false
+        css: false,
+        include: ['src/**/*.{test,spec}.{ts,tsx,js,jsx}']
       }
     }, {
       extends: true,


### PR DESCRIPTION
## Summary

- Adds the `@playwright/test` runner alongside the existing `playwright` lib (still used by Vitest's storybook-browser plugin) and the WebKit / Firefox / Chromium browser binaries.
- Adds `playwright.config.ts` plus 5 E2E specs (smoke, contact form, featured slider + lightbox, MomentumTabs, SkillsCarousel TS-icon white-bg pseudo). The webServer auto-starts vite with `VITE_MOCK_FORM=success` so the contact-form spec hits the in-component mock instead of Web3Forms.
- Adds the `chromatic` CLI, root config (TurboSnap on, exit-once-uploaded, skip `main`), and npm scripts. The `@chromatic-com/storybook` addon was already wired in `.storybook/main.js`.
- Pins the Vitest unit project to `src/**/*.{test,spec}.*` so it doesn't try to run Playwright's `e2e/*.spec.ts` files.

Closes #34 and #35.

## New npm scripts

- `npm run e2e` / `e2e:ui` / `e2e:headed` / `e2e:install`
- `npm run chromatic` / `chromatic:baseline`

## Before merging — Chromatic project setup

Miguel needs to:

1. Sign in at [chromatic.com](https://www.chromatic.com) with GitHub
2. Create / link the `migueldotl-portfolio` project
3. Copy the project token from the project's Manage page
4. `export CHROMATIC_PROJECT_TOKEN=<token>` (or add to `.env.local`)
5. `npm run chromatic:baseline` — first build accepts all 19 stories as the baseline; subsequent `npm run chromatic` runs flag diffs

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean dist
- [x] `npm test` — 57 unit tests pass, e2e specs no longer picked up
- [x] `npm run e2e -- --project=chromium` smoke (6/6) + featured-slider (2/2) + momentum-tabs (3/3) + skills-carousel (1/1) pass against existing dev server
- [ ] `npm run e2e` — full Chromium + Firefox + WebKit run against a fresh dev server (Miguel: `npm run e2e:install` first if browsers are missing)
- [ ] `npm run chromatic:baseline` after Chromatic project is created