### PR TITLE
chore: rename package + README to migueldotl-portfolio (#80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ _[TODO: Miguel — short paragraph in your own voice: who you are, what you buil
 ## Local development
 
 ```bash
-git clone https://github.com/MiguelDotL/react-portfolio.git
-cd react-portfolio
+git clone https://github.com/MiguelDotL/migueldotl-portfolio.git
+cd migueldotl-portfolio
 npm install
 npm run dev
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "react-portfolio",
+  "name": "migueldotl-portfolio",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "react-portfolio",
+      "name": "migueldotl-portfolio",
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-portfolio",
+  "name": "migueldotl-portfolio",
   "version": "0.1.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

Pre-public-blocker for #79 (public Storybook). GitHub repo + remote URL already point to `migueldotl-portfolio`; this catches the rest:

- `package.json` `name` → `migueldotl-portfolio`
- `package-lock.json` regenerated under the new name
- `README.md` clone command + `cd` updated

Verified clean: `npx tsc --noEmit` + `npm run build` + grep for `react-portfolio` returns no remaining references in repo (excluding node_modules / build artifacts).

Closes #80 except for the local directory rename — see below.

## Action item for Miguel after merge

The local working directory at `/Users/mbp2019/Projects/react-portfolio` still has the old name. To complete the rename:

1. Stop the dev server (currently on :3000)
2. Close any editor windows / tabs scoped to the old path
3. `mv /Users/mbp2019/Projects/react-portfolio /Users/mbp2019/Projects/migueldotl-portfolio`
4. Restart dev server / reopen editor on the new path
5. Update `/Users/mbp2019/Projects/CLAUDE.md` if it references the old path (currently no references found)

Once that's done, #80 is fully complete.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `grep -r react-portfolio` returns 0 stragglers in repo
- [ ] Vercel preview deploy succeeds (will run on push)