### PR TITLE
fix: make active tab transparent (drop frosted-glass fill)

### DIFF
--- a/src/assets/styles/MomentumTabs.css
+++ b/src/assets/styles/MomentumTabs.css
@@ -32,15 +32,13 @@
     outline: none;
 }
 
-/* Frosted-glass background fades in once the perimeter trace finishes wrapping
-   the active tab. Pseudo-element sits behind the text inside the tab area. */
+/* Active-tab fill layer — kept transparent. Perimeter trace alone marks
+   the active tab; the pseudo + .is-frosted toggle stay so a future skin
+   can drop a background back in without re-wiring the JS animation. */
 .momentum-tab::before {
     content: "";
     position: absolute;
     inset: 0;
-    background: rgba(255, 255, 255, 0.05);
-    backdrop-filter: blur(6px) saturate(1.3);
-    -webkit-backdrop-filter: blur(6px) saturate(1.3);
     opacity: 0;
     transition: opacity 280ms ease;
     pointer-events: none;


### PR DESCRIPTION
## Summary

Active tab was getting a `rgba(255,255,255,0.05)` tint + `backdrop-filter: blur(6px) saturate(1.3)` — visual noise on top of the perimeter trace, which already marks the active tab clearly.

Pseudo + `.is-frosted` class kept (with empty background) so a future skin can drop a fill back in without re-wiring MomentumTabs.tsx animation timing.

Side benefit: one fewer stacked `backdrop-filter` layer on the Projects section.

## Test plan

- [ ] Refresh, click between Featured / Personal / Client tabs
- [ ] Active tab has no fill — only the perimeter trace marks it
- [ ] Animation timing unchanged (still hits the `.is-frosted` toggle, just no visible effect now)