### PR TITLE
feat: storybook coverage parity (#79 Phase 1)

### DIFF
--- a/src/components/ContactForm.stories.tsx
+++ b/src/components/ContactForm.stories.tsx
@@ -1,4 +1,7 @@
-import type { Meta } from '@storybook/react-vite';
+import { useEffect } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, within } from 'storybook/test';
+import axios from 'axios';
 import ContactForm from './ContactForm';
 import '../assets/styles/Contact.css';
 
@@ -26,4 +29,142 @@ const meta: Meta<typeof ContactForm> = {
 
 export default meta;
 
-export const Empty = {};
+type Story = StoryObj<typeof ContactForm>;
+
+// Untouched form. Matches the live state on first paint.
+export const Empty: Story = {};
+
+// Helper: fill every required field via userEvent so the snapshot
+// captures the form mid-flow with realistic content. Used as the
+// shared first step for Submitting / Success / Error too.
+const fillFields = async (canvas: ReturnType<typeof within>) => {
+    await userEvent.type(
+        canvas.getByPlaceholderText(/First Name/i),
+        'Miguel'
+    );
+    await userEvent.type(
+        canvas.getByPlaceholderText(/Last Name/i),
+        'Lozano'
+    );
+    await userEvent.type(
+        canvas.getByPlaceholderText(/Email Address/i),
+        'miguel@example.com'
+    );
+    await userEvent.type(
+        canvas.getByPlaceholderText(/Phone Number/i),
+        '5555550100'
+    );
+    await userEvent.type(
+        canvas.getByPlaceholderText(/Message/i),
+        "Loved your portfolio — would like to chat about a senior frontend role."
+    );
+};
+
+// All required fields filled, no submit yet. Stable visual snapshot.
+export const Filled: Story = {
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await fillFields(canvas);
+        await expect(canvas.getByPlaceholderText(/First Name/i)).toHaveValue(
+            'Miguel'
+        );
+    }
+};
+
+// Per-story axios.post mock decorator. Patches the module on mount,
+// restores on unmount. Each story can pick the response shape it needs
+// without depending on VITE_MOCK_FORM env state at build time.
+type MockResponse =
+    | { kind: 'success' }
+    | { kind: 'spam-rejected' }
+    | { kind: 'network-error' }
+    | { kind: 'never-resolves' };
+
+const useAxiosPostMock = (response: MockResponse, delayMs = 800) => {
+    useEffect(() => {
+        const original = axios.post;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (axios as any).post = () =>
+            new Promise((resolve, reject) => {
+                if (response.kind === 'never-resolves') return; // intentional
+                setTimeout(() => {
+                    if (response.kind === 'success') {
+                        resolve({
+                            status: 200,
+                            data: { success: true, message: '[MOCK] Email sent' }
+                        });
+                    } else if (response.kind === 'spam-rejected') {
+                        resolve({
+                            status: 200,
+                            data: {
+                                success: false,
+                                message: '[MOCK] Spam detected'
+                            }
+                        });
+                    } else if (response.kind === 'network-error') {
+                        reject(new globalThis.Error('[MOCK] Network request failed'));
+                    }
+                }, delayMs);
+            });
+        return () => {
+            axios.post = original;
+        };
+    }, [response, delayMs]);
+};
+
+const MockedContactForm = ({
+    response,
+    delayMs
+}: {
+    response: MockResponse;
+    delayMs?: number;
+}) => {
+    useAxiosPostMock(response, delayMs);
+    return <ContactForm />;
+};
+
+// Mid-submit state. The mock never resolves so the "Sending..." button
+// label stays pinned, useful for capturing the in-flight visual.
+export const Submitting: Story = {
+    render: () => <MockedContactForm response={{ kind: 'never-resolves' }} />,
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await fillFields(canvas);
+        await userEvent.click(canvas.getByRole('button', { name: /send/i }));
+        await expect(
+            canvas.getByRole('button', { name: /sending/i })
+        ).toBeDisabled();
+    }
+};
+
+// Happy path. Mock resolves with success: true after a short delay so
+// the play function can wait for the post-submit UI to render.
+export const Success: Story = {
+    render: () => (
+        <MockedContactForm response={{ kind: 'success' }} delayMs={50} />
+    ),
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await fillFields(canvas);
+        await userEvent.click(canvas.getByRole('button', { name: /send/i }));
+        await expect(
+            await canvas.findByText(/Thanks for reaching out/i)
+        ).toBeInTheDocument();
+    }
+};
+
+// Failure path. Mock rejects with a network error so the form surfaces
+// the "Oops! Request Failed" message.
+export const Error: Story = {
+    render: () => (
+        <MockedContactForm response={{ kind: 'network-error' }} delayMs={50} />
+    ),
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await fillFields(canvas);
+        await userEvent.click(canvas.getByRole('button', { name: /send/i }));
+        await expect(
+            await canvas.findByText(/Oops! Request Failed/i)
+        ).toBeInTheDocument();
+    }
+};

--- a/src/components/FeaturedImageSlider.stories.tsx
+++ b/src/components/FeaturedImageSlider.stories.tsx
@@ -1,0 +1,121 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Container, Row } from 'react-bootstrap';
+import FeaturedImageSlider, {
+    type SliderControl,
+    type SliderIndicator
+} from './FeaturedImageSlider';
+import '../assets/styles/Projects.css';
+import '../assets/styles/FeaturedImageSlider.css';
+
+import bcbsMain from '../assets/images/projects/bcbs-main.png';
+import bcbsLitehouse from '../assets/images/projects/bcbs-litehouse.png';
+import bcbsProviders from '../assets/images/projects/bcbs-providers.png';
+import voicepoolImg from '../assets/images/projects/voicepool.png';
+
+const triptych = [
+    { src: bcbsMain, alt: 'BCBS NC homepage' },
+    { src: bcbsLitehouse, alt: 'BCBS NC vision plan page' },
+    { src: bcbsProviders, alt: 'BCBS NC providers page' }
+];
+
+const single = [{ src: voicepoolImg, alt: 'Voicepool fleet dashboard' }];
+
+type StoryArgs = {
+    images: { src: string; alt: string }[];
+    indicator: SliderIndicator;
+    controls: SliderControl[];
+    intervalMs: number;
+    imagePosition: string;
+};
+
+const meta: Meta<StoryArgs> = {
+    title: 'Components/FeaturedImageSlider',
+    decorators: [
+        (Story) => (
+            <section
+                className="projects"
+                style={{ background: 'var(--almost-black)', padding: '3rem 1rem' }}
+            >
+                <Container>
+                    <Row>
+                        <div
+                            className="featured-project-image"
+                            style={{ aspectRatio: '16 / 9', maxWidth: '720px' }}
+                        >
+                            <Story />
+                        </div>
+                    </Row>
+                </Container>
+            </section>
+        )
+    ],
+    parameters: { layout: 'fullscreen' },
+    argTypes: {
+        indicator: {
+            control: { type: 'radio' },
+            options: [
+                'frosted-dots',
+                'counter',
+                'segmented-progress',
+                'outlined-dots'
+            ],
+            description: 'Visual variant for the active-slide indicator'
+        },
+        controls: {
+            control: { type: 'check' },
+            options: ['arrows', 'click-image', 'keyboard', 'swipe'],
+            description:
+                'Interaction methods. Auto-advance + hover-pause are always on.'
+        },
+        intervalMs: {
+            control: { type: 'number', min: 1500, max: 12000, step: 500 },
+            description: 'Auto-advance interval in milliseconds'
+        },
+        imagePosition: {
+            control: { type: 'text' },
+            description: 'CSS object-position applied to each slide image'
+        }
+    },
+    args: {
+        images: triptych,
+        indicator: 'frosted-dots',
+        controls: [],
+        intervalMs: 3690,
+        imagePosition: 'center'
+    },
+    render: (args) => (
+        <FeaturedImageSlider
+            images={args.images}
+            indicator={args.indicator}
+            controls={args.controls}
+            intervalMs={args.intervalMs}
+            imagePosition={args.imagePosition}
+        />
+    )
+};
+
+export default meta;
+
+type Story = StoryObj<StoryArgs>;
+
+export const SingleImage: Story = {
+    args: { images: single }
+};
+
+export const Triptych: Story = {
+    args: { images: triptych }
+};
+
+export const WithArrows: Story = {
+    args: {
+        images: triptych,
+        controls: ['arrows']
+    }
+};
+
+export const WithKeyboardAndSwipe: Story = {
+    args: {
+        images: triptych,
+        controls: ['keyboard', 'swipe']
+    }
+};

--- a/src/components/FeaturedProjectCardSkeleton.stories.tsx
+++ b/src/components/FeaturedProjectCardSkeleton.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Container, Row } from 'react-bootstrap';
+import FeaturedProjectCardSkeleton from './FeaturedProjectCardSkeleton';
+import '../assets/styles/Projects.css';
+
+const meta: Meta<typeof FeaturedProjectCardSkeleton> = {
+    title: 'Components/FeaturedProjectCardSkeleton',
+    component: FeaturedProjectCardSkeleton,
+    decorators: [
+        (Story) => (
+            <section
+                className="projects"
+                style={{ background: 'var(--almost-black)', padding: '3rem 1rem' }}
+            >
+                <Container>
+                    <Row>
+                        <Story />
+                    </Row>
+                </Container>
+            </section>
+        )
+    ],
+    parameters: { layout: 'fullscreen' }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FeaturedProjectCardSkeleton>;
+
+export const Default: Story = {};
+
+// Matches the live two-up Featured grid so the shimmer placeholders
+// render at the same width they would during a real load.
+export const Pair: Story = {
+    render: () => (
+        <>
+            <FeaturedProjectCardSkeleton />
+            <FeaturedProjectCardSkeleton />
+        </>
+    )
+};

--- a/src/components/HoverZoomPan.stories.tsx
+++ b/src/components/HoverZoomPan.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Container, Row } from 'react-bootstrap';
+import HoverZoomPan from './HoverZoomPan';
+import '../assets/styles/Projects.css';
+
+import branchBeaconImg from '../assets/images/projects/branch-beacon.png';
+
+type StoryArgs = {
+    src: string;
+    alt: string;
+    zoomScale: number;
+    transitionMs: number;
+};
+
+const meta: Meta<StoryArgs> = {
+    title: 'Components/HoverZoomPan',
+    decorators: [
+        (Story) => (
+            <section
+                className="projects"
+                style={{ background: 'var(--almost-black)', padding: '3rem 1rem' }}
+            >
+                <Container>
+                    <Row>
+                        <div
+                            className="featured-project-image"
+                            style={{ aspectRatio: '16 / 9', maxWidth: '720px' }}
+                        >
+                            <Story />
+                        </div>
+                    </Row>
+                </Container>
+            </section>
+        )
+    ],
+    parameters: { layout: 'fullscreen' },
+    argTypes: {
+        src: { table: { disable: true } },
+        alt: { control: { type: 'text' } },
+        zoomScale: {
+            control: { type: 'range', min: 1, max: 2.5, step: 0.05 },
+            description:
+                'Hover zoom multiplier. 1 = no zoom; 2.5 = 250% scale.'
+        },
+        transitionMs: {
+            control: { type: 'range', min: 100, max: 1500, step: 10 },
+            description: 'Zoom-in / zoom-out transition duration in ms'
+        }
+    },
+    args: {
+        src: branchBeaconImg,
+        alt: 'Branch Beacon screenshot',
+        zoomScale: 1.63,
+        transitionMs: 963
+    },
+    render: (args) => (
+        <HoverZoomPan
+            src={args.src}
+            alt={args.alt}
+            zoomScale={args.zoomScale}
+            transitionMs={args.transitionMs}
+        />
+    )
+};
+
+export default meta;
+
+type Story = StoryObj<StoryArgs>;
+
+export const Default: Story = {};
+
+export const SubtleZoom: Story = {
+    args: { zoomScale: 1.06 }
+};
+
+export const StrongerZoom: Story = {
+    args: { zoomScale: 2.25 }
+};

--- a/src/components/MomentumTabs.stories.tsx
+++ b/src/components/MomentumTabs.stories.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Container, Row } from 'react-bootstrap';
+import MomentumTabs from './MomentumTabs';
+import '../assets/styles/Projects.css';
+import '../assets/styles/MomentumTabs.css';
+
+type StoryArgs = {
+    tabs: readonly string[];
+    active: string;
+    enabled: boolean;
+};
+
+const meta: Meta<StoryArgs> = {
+    title: 'Components/MomentumTabs',
+    decorators: [
+        (Story) => (
+            <section
+                className="projects"
+                style={{ background: 'var(--almost-black)', padding: '4rem 1rem' }}
+            >
+                <Container>
+                    <Row>
+                        <Story />
+                    </Row>
+                </Container>
+            </section>
+        )
+    ],
+    parameters: { layout: 'fullscreen' },
+    argTypes: {
+        tabs: {
+            control: { type: 'object' },
+            description: 'Tab labels (rendered as `<label> Projects`)'
+        },
+        active: {
+            control: { type: 'text' },
+            description: 'Currently active tab — must match one of `tabs`'
+        },
+        enabled: {
+            control: { type: 'boolean' },
+            description:
+                'When false, holds the initial wrap animation. The live site flips this on intersection-observer.'
+        }
+    },
+    args: {
+        tabs: ['Client', 'Featured', 'Personal'],
+        active: 'Featured',
+        enabled: true
+    },
+    render: (args) => <StatefulMomentumTabs {...args} />
+};
+
+// Wrap in a stateful shell so the active tab updates on click — the
+// component requires an `onChange` to re-trigger animations, and a
+// pure-args story would re-mount on every interaction.
+const StatefulMomentumTabs = ({ tabs, active, enabled }: StoryArgs) => {
+    const [current, setCurrent] = useState(active);
+    return (
+        <MomentumTabs
+            tabs={tabs}
+            active={current}
+            enabled={enabled}
+            onChange={(tab) => setCurrent(tab)}
+        />
+    );
+};
+
+export default meta;
+
+type Story = StoryObj<StoryArgs>;
+
+export const Default: Story = {};
+
+export const LongLabels: Story = {
+    args: {
+        tabs: [
+            'Enterprise Engagements',
+            'Open Source Contributions',
+            'Personal Side Projects'
+        ],
+        active: 'Open Source Contributions'
+    }
+};
+
+export const TwoTabs: Story = {
+    args: {
+        tabs: ['Featured', 'Archive'],
+        active: 'Featured'
+    }
+};

--- a/src/components/NpmPlainIcon.stories.tsx
+++ b/src/components/NpmPlainIcon.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import NpmPlainIcon from './NpmPlainIcon';
+import '../assets/styles/Projects.css';
+
+type StoryArgs = {
+    size: number;
+    color: string;
+};
+
+const meta: Meta<StoryArgs> = {
+    title: 'Components/NpmPlainIcon',
+    component: NpmPlainIcon,
+    decorators: [
+        (Story) => (
+            <div
+                style={{
+                    background: 'var(--almost-black)',
+                    padding: '3rem',
+                    color: '#fff',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    minHeight: '160px'
+                }}
+            >
+                <Story />
+            </div>
+        )
+    ],
+    parameters: { layout: 'fullscreen' },
+    argTypes: {
+        size: {
+            control: { type: 'range', min: 8, max: 128, step: 1 },
+            description: 'Icon width/height in pixels'
+        },
+        color: {
+            control: { type: 'color' },
+            description: 'Renders via fill=currentColor — sets the wrapper color'
+        }
+    },
+    args: {
+        size: 16,
+        color: '#ffffff'
+    },
+    render: (args) => (
+        <span style={{ color: args.color, display: 'inline-flex' }}>
+            <NpmPlainIcon size={args.size} />
+        </span>
+    )
+};
+
+export default meta;
+
+type Story = StoryObj<StoryArgs>;
+
+// Default size + color matches how Projects.tsx uses it inside Branch
+// Beacon's npm action chips (16px, white text on a dark button).
+export const Default: Story = {};
+
+// Renders inside a mocked button chip the same way Projects.tsx places
+// it inside `.featured-project-action-icon` next to the action label.
+export const InActionChip: Story = {
+    render: () => (
+        <a
+            href="#"
+            className="btn btn-outline-secondary"
+            onClick={(e) => e.preventDefault()}
+            style={{ pointerEvents: 'none' }}
+        >
+            <span className="featured-project-action-icon">
+                <NpmPlainIcon />
+            </span>
+            React
+        </a>
+    )
+};
+
+// Larger size for situations like a detail page or hero callout.
+export const Large: Story = {
+    args: { size: 96 }
+};
+
+// Inherits accent color via currentColor.
+export const Accent: Story = {
+    args: { color: '#AA367C' }
+};

--- a/src/components/ProjectCardSkeleton.stories.tsx
+++ b/src/components/ProjectCardSkeleton.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Container, Row } from 'react-bootstrap';
+import ProjectCardSkeleton from './ProjectCardSkeleton';
+import '../assets/styles/Projects.css';
+
+const meta: Meta<typeof ProjectCardSkeleton> = {
+    title: 'Components/ProjectCardSkeleton',
+    component: ProjectCardSkeleton,
+    decorators: [
+        (Story) => (
+            <section
+                className="projects"
+                style={{ background: 'var(--almost-black)', padding: '3rem 1rem' }}
+            >
+                <Container>
+                    <Row>
+                        <Story />
+                    </Row>
+                </Container>
+            </section>
+        )
+    ],
+    parameters: { layout: 'fullscreen' },
+    argTypes: {
+        md: {
+            control: { type: 'number', min: 2, max: 12, step: 1 },
+            description:
+                'Bootstrap column width at md breakpoint. 4 = 3-up grid (Client tab default).'
+        }
+    }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ProjectCardSkeleton>;
+
+export const Default: Story = {};
+
+// Matches the live Client-tab grid: 6 placeholder cards in a 3-up md layout.
+export const ClientGrid: Story = {
+    render: () => (
+        <>
+            {Array.from({ length: 6 }).map((_, i) => (
+                <ProjectCardSkeleton key={i} />
+            ))}
+        </>
+    )
+};
+
+// Two-up variant for narrower contexts.
+export const HalfWidth: Story = {
+    args: { md: 6 }
+};

--- a/src/components/Projects.stories.tsx
+++ b/src/components/Projects.stories.tsx
@@ -1,6 +1,24 @@
+import type { ReactNode } from 'react';
+import type { Meta } from '@storybook/react-vite';
+import { Col, Container, Row } from 'react-bootstrap';
 import Projects from './Projects';
+import FeaturedProjectCard from './FeaturedProjectCard';
+import FeaturedImageSlider from './FeaturedImageSlider';
+import ProjectList from './ProjectList';
+import '../assets/styles/Projects.css';
 
-const meta = {
+import generalProvision from '../assets/images/projects/general-provision-512.png';
+import trimAgency from '../assets/images/projects/trim-agency-512.png';
+import cSolutions from '../assets/images/projects/c-solutions-512.png';
+import filthyFood from '../assets/images/projects/filthy-food-512.png';
+import federated from '../assets/images/projects/federated-512.png';
+import orbyTV from '../assets/images/projects/orby-tv-2-512.png';
+import voicepoolImg from '../assets/images/projects/voicepool.png';
+import patternArchiveDashboard from '../assets/images/projects/pattern-archive-dashboard.png';
+import patternArchiveWizard from '../assets/images/projects/pattern-archive-wizard-editor.png';
+import patternArchiveLibrary from '../assets/images/projects/pattern-archive-library.png';
+
+const meta: Meta<typeof Projects> = {
     title: 'Sections/Projects',
     component: Projects,
     parameters: { layout: 'fullscreen' }
@@ -8,4 +26,162 @@ const meta = {
 
 export default meta;
 
+// Default renders the full Projects section (Featured tab is the default).
+// The MomentumTabs animation runs as it does on the live site.
 export const Default = {};
+
+// `ClientTab` and `PersonalTab` render the inner per-tab content (the same
+// `<Row>` Projects.tsx renders for those tabs) wrapped in the section
+// chrome. This skips MomentumTabs entirely so the snapshots are stable —
+// MomentumTabs gets its own dedicated story.
+const tabSectionDecorator = (children: ReactNode) => (
+    <section
+        className="projects"
+        style={{ background: 'var(--almost-black)', padding: '3rem 1rem' }}
+    >
+        <Container>
+            <Row>
+                <Col>
+                    <div className="content">
+                        <h2>Projects</h2>
+                        {children}
+                    </div>
+                </Col>
+            </Row>
+        </Container>
+    </section>
+);
+
+const clientProjects = [
+    {
+        title: 'T R I M Agency',
+        description: 'Web Development',
+        imageURL: trimAgency,
+        url: '//www.trimagency.com/'
+    },
+    {
+        title: 'C Solutions',
+        description: 'Web Development',
+        imageURL: cSolutions,
+        url: '//csolutions-us.com/'
+    },
+    {
+        title: 'Orby TV',
+        description: 'Web Development',
+        imageURL: orbyTV,
+        url: '//orbytv.com/'
+    },
+    {
+        title: 'Federated Insurance',
+        description: 'Web Development',
+        imageURL: federated,
+        url: '//www.federated.ca/'
+    },
+    {
+        title: 'Filthy Food',
+        description: 'Ecommerce',
+        imageURL: filthyFood,
+        url: '//filthyfood.com/'
+    },
+    {
+        title: 'General Provision',
+        description: 'Web Development',
+        imageURL: generalProvision,
+        url: '//generalprovision.com/'
+    }
+];
+
+export const ClientTab = {
+    render: () =>
+        tabSectionDecorator(<ProjectList projects={clientProjects} />)
+};
+
+export const PersonalTab = {
+    render: () =>
+        tabSectionDecorator(
+            <Row>
+                <FeaturedProjectCard
+                    title="Voicepool"
+                    subtitle="Custom dashboard"
+                    description="Open-source dashboard for managing a fleet of ElevenLabs accounts. Tracks account usage, routes TTS calls to whichever account has the most capacity, and provisions new accounts end-to-end with one click."
+                    techStack={[
+                        'TypeScript',
+                        'React',
+                        'Vite',
+                        'Express',
+                        'Playwright',
+                        'ElevenLabs API'
+                    ]}
+                    imageSlot={
+                        <FeaturedImageSlider
+                            images={[
+                                {
+                                    src: voicepoolImg,
+                                    alt: 'Voicepool fleet dashboard'
+                                }
+                            ]}
+                        />
+                    }
+                    actions={[
+                        {
+                            label: 'Repo',
+                            url: 'https://github.com/MiguelDotL/voicepool',
+                            icon: (
+                                <i
+                                    className="devicon-github-original"
+                                    aria-hidden
+                                />
+                            )
+                        }
+                    ]}
+                />
+                <FeaturedProjectCard
+                    title="Pattern Archive"
+                    subtitle="Automated video pipeline"
+                    description="Video production pipeline with a Storybook-driven React UI, AI-assisted script generation driven by a structured prompt guide, and end-to-end automation from script to publish. Each iteration informed by real use."
+                    techStack={[
+                        'React',
+                        'FastAPI',
+                        'Whisper',
+                        'FFmpeg',
+                        'YouTube Data API'
+                    ]}
+                    imageSlot={
+                        <FeaturedImageSlider
+                            images={[
+                                {
+                                    src: patternArchiveDashboard,
+                                    alt: 'Pattern Archive dashboard with active build queue'
+                                },
+                                {
+                                    src: patternArchiveLibrary,
+                                    alt: 'Pattern Archive library with ready-to-publish queue and uploaded videos'
+                                },
+                                {
+                                    src: patternArchiveWizard,
+                                    alt: 'Pattern Archive wizard editor with timeline and clip pool'
+                                }
+                            ]}
+                            controls={['arrows', 'keyboard', 'swipe']}
+                            imagePosition="top"
+                        />
+                    }
+                    actions={[
+                        {
+                            label: 'Repo',
+                            url: 'https://github.com/MiguelDotL/PatternArchive',
+                            icon: (
+                                <i
+                                    className="devicon-github-original"
+                                    aria-hidden
+                                />
+                            ),
+                            disabled: true,
+                            disabledReason: 'Private repo'
+                        }
+                    ]}
+                />
+            </Row>
+        )
+};
+


### PR DESCRIPTION
## Summary

Phase 1 of the Storybook overhaul plan (`/Users/mbp2019/.claude/plans/storybook-portfolio-overhaul.md`). Closes Chromatic visual-regression blind spots and adds stories for every component that can render to a user. Pure code; no IA / MDX / narrative work in this PR (those land in later phases).

This addresses #79's coverage gaps but **does not close #79** — Phases 2–5 (connected controls, MDX docs, IA restructure, exploration narratives) remain.

## Commits

- `feat(storybook): cover Personal and Client project tabs` — splits `Projects.stories.tsx` so Chromatic captures the Client and Personal tabs (previously invisible behind the default Featured tab). Per-tab stories render the inner `<Row>` directly with the same data as `Projects.tsx`, skipping `MomentumTabs` to keep snapshots animation-stable.
- `feat(storybook): add stories for MomentumTabs, FeaturedImageSlider, HoverZoomPan` — three new `Components/*` stories. MomentumTabs gets `Default`, `LongLabels`, `TwoTabs` with `tabs`/`active`/`enabled` controls. FeaturedImageSlider gets `SingleImage`, `Triptych`, `WithArrows`, `WithKeyboardAndSwipe` with connected `indicator`/`controls`/`intervalMs`/`imagePosition` controls. HoverZoomPan gets `Default`, `SubtleZoom`, `StrongerZoom` with range controls for `zoomScale` (1.0–2.5) and `transitionMs` (100–1500), framed in a 16:9 wrapper using `branch-beacon.png`.
- `feat(storybook): add stories for NpmPlainIcon and skeleton components` — `NpmPlainIcon` with `Default`/`InActionChip`/`Large`/`Accent` variants; `FeaturedProjectCardSkeleton` with `Default`/`Pair`; `ProjectCardSkeleton` with `Default`/`ClientGrid`/`HalfWidth`. All wrapped in the same `Container`/`Row` decorator other Featured-tab stories use so widths match real load layouts.
- `feat(storybook): add ContactForm state variants (filled, submitting, success, error)` — extends the existing `Empty` story with `Filled`, `Submitting`, `Success`, `Error`. Each post-submit story patches `axios.post` via a small `useEffect`-based decorator so the in-flight, success, and failure visuals are deterministic — no dependency on `VITE_MOCK_FORM` env state at build time. `Submitting` uses a never-resolving mock so the "Sending..." button label stays pinned for the snapshot. `Success`/`Error` await their respective post-submit message via `play` + `storybook/test`.

## Verification

- `npx tsc --noEmit` — clean
- `npm run build-storybook` — builds successfully (4.3s)
- All new stories are CSF objects (no MDX), so the storybook-vitest browser test runner can pick them up

## Test plan

- [ ] `npm run storybook` and confirm all new stories render
- [ ] Chromatic baseline picks up new snapshots (additive — no story renames in this PR)
- [ ] Confirm ContactForm `Submitting`/`Success`/`Error` plays render the expected post-submit visual