### PR TITLE
fix: restore active-tab frost radius to 10px

### DIFF
--- a/src/assets/styles/MomentumTabs.css
+++ b/src/assets/styles/MomentumTabs.css
@@ -39,8 +39,8 @@
     position: absolute;
     inset: 0;
     background: rgba(255, 255, 255, 0.05);
-    backdrop-filter: blur(6px) saturate(1.3);
-    -webkit-backdrop-filter: blur(6px) saturate(1.3);
+    backdrop-filter: blur(10px) saturate(1.3);
+    -webkit-backdrop-filter: blur(10px) saturate(1.3);
     opacity: 0;
     transition: opacity 280ms ease;
     pointer-events: none;


### PR DESCRIPTION
Last week's perf sweep dropped backdrop-filter blur from 10px → 6px across the projects section. The active tab in particular reads better at the original 10px — restoring just that one. Other surfaces (chips, action buttons, slider dots) stay at 6px.