### PR TITLE
feat: storybook phase 2 — connected controls + Playgrounds (#79)

### DIFF
--- a/src/components/FeaturedImageSlider.stories.tsx
+++ b/src/components/FeaturedImageSlider.stories.tsx
@@ -51,6 +51,10 @@ const meta: Meta<StoryArgs> = {
     ],
     parameters: { layout: 'fullscreen' },
     argTypes: {
+        images: {
+            control: { type: 'object' },
+            description: 'Slides to cycle through (src + alt)'
+        },
         indicator: {
             control: { type: 'radio' },
             options: [
@@ -59,21 +63,21 @@ const meta: Meta<StoryArgs> = {
                 'segmented-progress',
                 'outlined-dots'
             ],
-            description: 'Visual variant for the active-slide indicator'
+            description: 'Visual style for the active-slide indicator'
         },
         controls: {
             control: { type: 'check' },
             options: ['arrows', 'click-image', 'keyboard', 'swipe'],
             description:
-                'Interaction methods. Auto-advance + hover-pause are always on.'
+                'Enabled input methods (multiselect); autoplay + hover-pause always on'
         },
         intervalMs: {
             control: { type: 'number', min: 1500, max: 12000, step: 500 },
-            description: 'Auto-advance interval in milliseconds'
+            description: 'Autoplay interval in milliseconds'
         },
         imagePosition: {
             control: { type: 'text' },
-            description: 'CSS object-position applied to each slide image'
+            description: 'CSS object-position applied to each slide'
         }
     },
     args: {

--- a/src/components/FeaturedProjectCard.stories.tsx
+++ b/src/components/FeaturedProjectCard.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta } from '@storybook/react-vite';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Container, Row } from 'react-bootstrap';
 import FeaturedProjectCard from './FeaturedProjectCard';
 import NpmPlainIcon from './NpmPlainIcon';
@@ -26,12 +26,44 @@ const meta: Meta<typeof FeaturedProjectCard> = {
             </section>
         )
     ],
-    parameters: { layout: 'fullscreen' }
+    parameters: { layout: 'fullscreen' },
+    argTypes: {
+        title: {
+            control: { type: 'text' },
+            description: 'Project name shown as heading'
+        },
+        subtitle: {
+            control: { type: 'text' },
+            description: 'Optional eyebrow above title'
+        },
+        description: {
+            control: { type: 'text' },
+            description: 'Project body copy'
+        },
+        techStack: {
+            control: { type: 'object' },
+            description: 'Tech tags listed under description'
+        },
+        imageURL: {
+            control: { type: 'text' },
+            description: 'Image src; ignored when imageSlot is provided'
+        },
+        imageSlot: {
+            control: false,
+            description: 'Custom image node; takes precedence over imageURL'
+        },
+        actions: {
+            control: { type: 'object' },
+            description: 'Link/action buttons rendered below body'
+        }
+    }
 };
 
 export default meta;
 
-export const BranchBeacon = {
+type Story = StoryObj<typeof FeaturedProjectCard>;
+
+export const BranchBeacon: Story = {
     args: {
         title: 'branch-beacon',
         subtitle: 'First npm package',
@@ -59,7 +91,7 @@ export const BranchBeacon = {
     }
 };
 
-export const BcbsNc = {
+export const BcbsNc: Story = {
     args: {
         title: 'BCBS NC — LiteHouse',
         subtitle: 'Enterprise client',
@@ -73,7 +105,7 @@ export const BcbsNc = {
     }
 };
 
-export const BothFeatured = {
+export const BothFeatured: Story = {
     render: () => (
         <>
             <FeaturedProjectCard
@@ -110,4 +142,15 @@ export const BothFeatured = {
             />
         </>
     )
+};
+
+export const Playground: Story = {
+    args: {
+        title: 'Sample Project',
+        subtitle: 'Playground',
+        description: 'Edit any control to preview the card layout.',
+        techStack: ['React', 'TypeScript'],
+        imageURL: placeholderBranchBeacon,
+        actions: [{ label: 'View', url: '#' }]
+    }
 };

--- a/src/components/HoverZoomPan.stories.tsx
+++ b/src/components/HoverZoomPan.stories.tsx
@@ -69,6 +69,8 @@ type Story = StoryObj<StoryArgs>;
 
 export const Default: Story = {};
 
+export const Playground: Story = {};
+
 export const SubtleZoom: Story = {
     args: { zoomScale: 1.06 }
 };

--- a/src/components/MomentumTabs.stories.tsx
+++ b/src/components/MomentumTabs.stories.tsx
@@ -72,6 +72,8 @@ type Story = StoryObj<StoryArgs>;
 
 export const Default: Story = {};
 
+export const Playground: Story = {};
+
 export const LongLabels: Story = {
     args: {
         tabs: [

--- a/src/components/ProjectCard.stories.tsx
+++ b/src/components/ProjectCard.stories.tsx
@@ -1,5 +1,6 @@
-import type { Meta } from '@storybook/react-vite';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Row } from 'react-bootstrap';
+import { userEvent, within } from 'storybook/test';
 import ProjectCard from './ProjectCard';
 import '../assets/styles/Projects.css';
 
@@ -24,12 +25,20 @@ const meta: Meta<typeof ProjectCard> = {
     ],
     parameters: {
         layout: 'fullscreen'
+    },
+    argTypes: {
+        title: { control: { type: 'text' }, description: 'Project name' },
+        description: { control: { type: 'text' }, description: 'Short tagline' },
+        imageURL: { control: { type: 'text' }, description: 'Image src' },
+        url: { control: { type: 'text' }, description: 'Click-through URL' }
     }
 };
 
 export default meta;
 
-export const Default = {
+type Story = StoryObj<typeof ProjectCard>;
+
+export const Default: Story = {
     args: {
         title: 'Orby TV',
         description: 'Web Development',
@@ -38,7 +47,7 @@ export const Default = {
     }
 };
 
-export const LongTitle = {
+export const LongTitle: Story = {
     args: {
         title: 'A Project With An Unusually Long Title',
         description: 'Web Development',
@@ -47,12 +56,36 @@ export const LongTitle = {
     }
 };
 
-export const LongDescription = {
+export const LongDescription: Story = {
     args: {
         title: 'Filthy Food',
         description:
             'A multi-paragraph description that wraps to multiple lines to verify hover overlay layout',
         imageURL: filthyFood,
         url: '#'
+    }
+};
+
+export const Playground: Story = {
+    args: {
+        title: 'Sample Project',
+        description: 'Edit any control to preview',
+        imageURL: orbyTv,
+        url: '#'
+    }
+};
+
+// Drives the hover overlay state for snapshot coverage of the hovered look.
+export const Hovered: Story = {
+    args: {
+        title: 'Orby TV',
+        description: 'Web Development',
+        imageURL: orbyTv,
+        url: 'https://orby.tv'
+    },
+    play: async ({ canvasElement }) => {
+        const card = within(canvasElement).getAllByRole('img')[0]
+            .closest('.project-card');
+        if (card) await userEvent.hover(card);
     }
 };

--- a/src/components/ProjectList.stories.tsx
+++ b/src/components/ProjectList.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta } from '@storybook/react-vite';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Tab } from 'react-bootstrap';
 import ProjectList from './ProjectList';
 import '../assets/styles/Projects.css';
@@ -6,6 +6,9 @@ import '../assets/styles/Projects.css';
 import orbyTV from '../assets/images/projects/orby-tv-2-512.png';
 import cSolutions from '../assets/images/projects/c-solutions-512.png';
 import filthyFood from '../assets/images/projects/filthy-food-512.png';
+import trimAgency from '../assets/images/projects/trim-agency-512.png';
+import federated from '../assets/images/projects/federated-512.png';
+import generalProvision from '../assets/images/projects/general-provision-512.png';
 
 const sampleProjects = [
     { title: 'Orby TV', description: 'Web Development', imageURL: orbyTV, url: '//orbytv.com/' },
@@ -30,13 +33,50 @@ const meta: Meta<typeof ProjectList> = {
             </section>
         )
     ],
-    parameters: { layout: 'fullscreen' }
+    parameters: { layout: 'fullscreen' },
+    argTypes: {
+        projects: {
+            control: { type: 'object' },
+            description: 'Array of projects to render as cards'
+        }
+    }
 };
 
 export default meta;
 
-export const ThreeProjects = {
+type Story = StoryObj<typeof ProjectList>;
+
+export const ThreeProjects: Story = {
     args: {
         projects: sampleProjects
+    }
+};
+
+export const OneProject: Story = {
+    args: {
+        projects: [sampleProjects[0]]
+    }
+};
+
+export const SixProjects: Story = {
+    args: {
+        projects: [
+            { title: 'T R I M Agency', description: 'Web Development', imageURL: trimAgency, url: '//www.trimagency.com/' },
+            { title: 'C Solutions', description: 'Web Development', imageURL: cSolutions, url: '//csolutions-us.com/' },
+            { title: 'Orby TV', description: 'Web Development', imageURL: orbyTV, url: '//orbytv.com/' },
+            { title: 'Federated Insurance', description: 'Web Development', imageURL: federated, url: '//www.federated.ca/' },
+            { title: 'Filthy Food', description: 'Ecommerce', imageURL: filthyFood, url: '//filthyfood.com/' },
+            { title: 'General Provision', description: 'Web Development', imageURL: generalProvision, url: '//generalprovision.com/' }
+        ]
+    }
+};
+
+export const LongTitlesGrid: Story = {
+    args: {
+        projects: [
+            { title: 'Some Project With An Unusually Long Title', description: 'Web Development', imageURL: orbyTV, url: '#' },
+            { title: 'Another Long Project Title For Wrap Testing', description: 'Ecommerce + Backend Engineering', imageURL: cSolutions, url: '#' },
+            { title: 'A Third One With A Lot Of Words', description: 'Web Development', imageURL: filthyFood, url: '#' }
+        ]
     }
 };

--- a/src/components/SocialIcons.stories.tsx
+++ b/src/components/SocialIcons.stories.tsx
@@ -1,4 +1,5 @@
-import type { Meta } from '@storybook/react-vite';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { action } from 'storybook/actions';
 import SocialIcons from './SocialIcons';
 
 import linkedInIcon from '../assets/images/icons/linked-in.svg';
@@ -19,12 +20,24 @@ const meta: Meta<typeof SocialIcons> = {
                 <Story />
             </div>
         )
-    ]
+    ],
+    argTypes: {
+        config: {
+            control: { type: 'object' },
+            description: 'Icons to render (className, icon, url, label)'
+        },
+        onHover: {
+            action: 'iconHover',
+            description: 'Fires on per-icon hover with the icon label'
+        }
+    }
 };
 
 export default meta;
 
-export const NavBarSocials = {
+type Story = StoryObj<typeof SocialIcons>;
+
+export const NavBarSocials: Story = {
     args: {
         config: [
             {
@@ -49,7 +62,7 @@ export const NavBarSocials = {
     }
 };
 
-export const FooterSocials = {
+export const FooterSocials: Story = {
     args: {
         config: [
             { className: 'codepen', icon: codepenIcon, url: '//codepen.io/MiguelDotL', label: 'CodePen' },
@@ -58,5 +71,26 @@ export const FooterSocials = {
             { className: 'codecademy', icon: codecademyIcon, url: '//www.codecademy.com/profiles/MiguelDotL', label: 'Codecademy' },
             { className: 'duolingo', icon: duolingoIcon, url: '//www.duolingo.com/profile/MiguelDotL', label: 'Duolingo' }
         ]
+    }
+};
+
+export const Playground: Story = {
+    args: {
+        config: [
+            {
+                className: 'linked-in',
+                icon: linkedInIcon,
+                url: 'https://www.linkedin.com/in/migueldot/',
+                label: 'LinkedIn'
+            },
+            {
+                className: 'github',
+                icon: githubIcon,
+                url: '//github.com/MiguelDotL',
+                label: 'GitHub'
+            },
+            { className: 'codepen', icon: codepenIcon, url: '//codepen.io/MiguelDotL', label: 'CodePen' }
+        ],
+        onHover: action('iconHover')
     }
 };


### PR DESCRIPTION
## Summary

Phase 2 of the Storybook overhaul — adds Playground variants and connected controls so each component story doubles as an interactive playground.

Description strings are intentionally placeholder copy (3–8 words each). Phase 3 (docs pass) and Phase 5 (exploration narratives) will pair-code the actual portfolio-facing prose.

### Changes per file

- **FeaturedProjectCard**: argTypes for every prop, stories type-annotated as `StoryObj`
- **FeaturedImageSlider**: argTypes refined; `images` control added
- **MomentumTabs**: `Playground` variant
- **HoverZoomPan**: `Playground` variant
- **SocialIcons**: argTypes + `onHover` wired via `storybook/actions`; `Playground` variant
- **ProjectCard**: argTypes + `Playground` + `Hovered` (play-driven via `userEvent.hover`)
- **ProjectList**: argTypes + `OneProject` / `SixProjects` / `LongTitlesGrid` variants

Does NOT close #79 — Phases 3–5 still pending.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build-storybook` builds successfully (3.66s)
- [ ] Vercel preview deploy succeeds (auto on push)
- [ ] Open Storybook and click into each component → verify Playground controls work end-to-end