### PR TITLE
perf: rerender + animation pass on Projects section (#78)

### DIFF
--- a/src/components/FeaturedImageSlider.tsx
+++ b/src/components/FeaturedImageSlider.tsx
@@ -37,6 +37,12 @@ const FeaturedImageSlider = ({
     const [paused, setPaused] = useState(false);
     const [progress, setProgress] = useState(0);
     const [lightboxOpen, setLightboxOpen] = useState(false);
+    // Pause rAF when scrolled off-screen so multiple sliders don't keep ticking
+    // when the section isn't visible. Defaults to true so we don't autoplay
+    // until we've actually observed visibility (avoids a brief tick before the
+    // observer fires).
+    const [offScreen, setOffScreen] = useState(true);
+    const rootRef = useRef<HTMLDivElement>(null);
     const swipeStartX = useRef<number | null>(null);
 
     const useArrows = controls.includes('arrows');
@@ -48,8 +54,27 @@ const FeaturedImageSlider = ({
     const prev = () => setIndex((i) => (i - 1 + images.length) % images.length);
 
     // Pause autoplay while the lightbox is open so the slide doesn't advance
-    // out from under the user.
-    const effectivelyPaused = paused || lightboxOpen;
+    // out from under the user. Also pause when off-screen.
+    const effectivelyPaused = paused || lightboxOpen || offScreen;
+
+    useEffect(() => {
+        const el = rootRef.current;
+        if (!el) return;
+        // Skip when IntersectionObserver isn't available (e.g. older test envs).
+        if (typeof IntersectionObserver === 'undefined') {
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            setOffScreen(false);
+            return;
+        }
+        const io = new IntersectionObserver(
+            ([entry]) => {
+                setOffScreen(!entry.isIntersecting);
+            },
+            { rootMargin: '100px' }
+        );
+        io.observe(el);
+        return () => io.disconnect();
+    }, []);
 
     useEffect(() => {
         // Reset progress when the active slide changes so the segmented-progress
@@ -146,6 +171,7 @@ const FeaturedImageSlider = ({
 
     return (
         <div
+            ref={rootRef}
             className="featured-image-slider"
             tabIndex={useKeyboard ? 0 : -1}
             onMouseEnter={() => setPaused(true)}
@@ -161,6 +187,7 @@ const FeaturedImageSlider = ({
                     key={img.src}
                     src={img.src}
                     alt={img.alt}
+                    loading="lazy"
                     className={`featured-image-slider__slide ${
                         i === index ? 'is-active' : ''
                     } is-clickable`}

--- a/src/components/FeaturedProjectCard.tsx
+++ b/src/components/FeaturedProjectCard.tsx
@@ -41,7 +41,7 @@ const FeaturedProjectCard = (props: FeaturedProject) => {
             <div className="featured-project-card">
                 <div className="featured-project-image">
                     {props.imageSlot ?? (
-                        props.imageURL && <img src={props.imageURL} alt={props.title} />
+                        props.imageURL && <img src={props.imageURL} alt={props.title} loading="lazy" />
                     )}
                 </div>
                 <div className="featured-project-body">

--- a/src/components/HoverZoomPan.tsx
+++ b/src/components/HoverZoomPan.tsx
@@ -35,6 +35,7 @@ const HoverZoomPan = ({ src, alt, zoomScale = 1.63, transitionMs = 963 }: Props)
             <img
                 src={src}
                 alt={alt}
+                loading="lazy"
                 style={{
                     width: '100%',
                     height: '100%',

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -12,7 +12,7 @@ const ProjectCard = (props: Project) => {
         <Col sm={6} md={4}>
             <div className="project-card">
                 <div className="project-image">
-                    <img src={props.imageURL} alt={props.title} />
+                    <img src={props.imageURL} alt={props.title} loading="lazy" />
                     <div className="project-content">
                         <h4>{props.title}</h4>
                         <span>{props.description}</span>


### PR DESCRIPTION
## Summary

Two focused perf wins on the Projects section, both invisible to the user.

### 1. Pause FeaturedImageSlider rAF when off-screen

Each slider runs a `requestAnimationFrame` loop continuously to drive the segmented-progress fill + auto-advance. With BCBS + Pattern Archive sliders both on the page, two rAF loops keep ticking after the user has scrolled past Projects.

`IntersectionObserver` (100px rootMargin) pauses each slider when its root leaves viewport. Falls back to never-paused when IO isn't available (older test envs).

### 2. Lazy-load below-the-fold project images

Adds `loading="lazy"` to project image `<img>` tags. Hero stays eager. Projects/Skills/Contact all sit below the first viewport, so deferring those fetches cuts initial network cost without changing perceived behavior.

- ProjectCard
- FeaturedProjectCard (imageURL fallback)
- FeaturedImageSlider (each slide)
- HoverZoomPan (wrapped image)

## Out of scope (deferred to other tickets)

- Image format conversion (WebP/AVIF) → #37
- Lighthouse-driven optimization → #38
- Memoization audit on Projects.tsx — looked, but the Projects section already short-circuits cleanly via `displayedTab` swap; React.memo on the per-tab content blocks would shave microseconds at most. Not worth the noise without a measurable rerender being saved.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` 81/81 passing
- [ ] Vercel preview deploy (auto on push)
- [ ] DevTools Performance recording: scroll past Projects, confirm rAF stops
- [ ] DevTools Network: confirm project images deferred until in-viewport