### PR TITLE
refactor: storybook IA → Showcase/Components/Process taxonomy (#79 Phase 4)

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -16,6 +16,19 @@ const preview = {
       // 'error' - fail CI on a11y violations
       // 'off' - skip a11y checks entirely
       test: "todo"
+    },
+
+    options: {
+      // Showcase first (the portfolio narrative), Components second (the
+      // building blocks), Process last (the design-process artifacts).
+      // Within each top-level bucket, sub-buckets and stories sort alphabetically.
+      storySort: {
+        order: [
+          'Showcase', ['Sections'],
+          'Components', ['Composites', 'Primitives', 'Skeletons'],
+          'Process'
+        ]
+      }
     }
   },
 };

--- a/src/components/BranchBeaconImageExploration.stories.tsx
+++ b/src/components/BranchBeaconImageExploration.stories.tsx
@@ -13,7 +13,7 @@ type StoryArgs = {
 };
 
 const meta: Meta<StoryArgs> = {
-    title: 'Explorations/BranchBeaconImage',
+    title: 'Process/BranchBeaconImage',
     decorators: [
         (Story) => (
             <section

--- a/src/components/ContactForm.stories.tsx
+++ b/src/components/ContactForm.stories.tsx
@@ -6,7 +6,7 @@ import ContactForm from './ContactForm';
 import '../assets/styles/Contact.css';
 
 const meta: Meta<typeof ContactForm> = {
-    title: 'Components/ContactForm',
+    title: 'Components/Composites/ContactForm',
     component: ContactForm,
     decorators: [
         (Story) => (

--- a/src/components/ContactMe.stories.tsx
+++ b/src/components/ContactMe.stories.tsx
@@ -1,7 +1,7 @@
 import ContactMe from './ContactMe';
 
 const meta = {
-    title: 'Sections/ContactMe',
+    title: 'Showcase/Sections/ContactMe',
     component: ContactMe,
     parameters: { layout: 'fullscreen' }
 };

--- a/src/components/FeaturedImageSlider.stories.tsx
+++ b/src/components/FeaturedImageSlider.stories.tsx
@@ -29,7 +29,7 @@ type StoryArgs = {
 };
 
 const meta: Meta<StoryArgs> = {
-    title: 'Components/FeaturedImageSlider',
+    title: 'Components/Composites/FeaturedImageSlider',
     decorators: [
         (Story) => (
             <section

--- a/src/components/FeaturedImageSliderExploration.stories.tsx
+++ b/src/components/FeaturedImageSliderExploration.stories.tsx
@@ -21,7 +21,7 @@ type StoryArgs = {
 };
 
 const meta: Meta<StoryArgs> = {
-    title: 'Explorations/FeaturedImageSlider',
+    title: 'Process/FeaturedImageSlider',
     decorators: [
         (Story) => (
             <section

--- a/src/components/FeaturedProjectCard.stories.tsx
+++ b/src/components/FeaturedProjectCard.stories.tsx
@@ -11,7 +11,7 @@ const placeholderBranchBeacon = branchBeaconImg;
 const placeholderBcbs = bcbsMain;
 
 const meta: Meta<typeof FeaturedProjectCard> = {
-    title: 'Components/FeaturedProjectCard',
+    title: 'Components/Composites/FeaturedProjectCard',
     component: FeaturedProjectCard,
     decorators: [
         (Story) => (

--- a/src/components/FeaturedProjectCardSkeleton.stories.tsx
+++ b/src/components/FeaturedProjectCardSkeleton.stories.tsx
@@ -4,7 +4,7 @@ import FeaturedProjectCardSkeleton from './FeaturedProjectCardSkeleton';
 import '../assets/styles/Projects.css';
 
 const meta: Meta<typeof FeaturedProjectCardSkeleton> = {
-    title: 'Components/FeaturedProjectCardSkeleton',
+    title: 'Components/Skeletons/FeaturedProjectCardSkeleton',
     component: FeaturedProjectCardSkeleton,
     decorators: [
         (Story) => (

--- a/src/components/Footer.stories.tsx
+++ b/src/components/Footer.stories.tsx
@@ -1,7 +1,7 @@
 import Footer from './Footer';
 
 const meta = {
-    title: 'Sections/Footer',
+    title: 'Showcase/Sections/Footer',
     component: Footer,
     parameters: { layout: 'fullscreen' }
 };

--- a/src/components/Hero.stories.tsx
+++ b/src/components/Hero.stories.tsx
@@ -1,7 +1,7 @@
 import Hero from './Hero';
 
 const meta = {
-    title: 'Sections/Hero',
+    title: 'Showcase/Sections/Hero',
     component: Hero,
     parameters: { layout: 'fullscreen' }
 };

--- a/src/components/HeroContent.stories.tsx
+++ b/src/components/HeroContent.stories.tsx
@@ -5,7 +5,7 @@ import bitmojiSpacePlanet from '../assets/images/bitmoji/bitmoji-space-planet-2.
 import '../assets/styles/Hero.css';
 
 const meta: Meta<typeof HeroContent> = {
-    title: 'Components/HeroContent',
+    title: 'Components/Composites/HeroContent',
     component: HeroContent,
     decorators: [
         // Decorator mimics the parent Hero layout so HeroContent renders next to

--- a/src/components/HoverZoomPan.stories.tsx
+++ b/src/components/HoverZoomPan.stories.tsx
@@ -13,7 +13,7 @@ type StoryArgs = {
 };
 
 const meta: Meta<StoryArgs> = {
-    title: 'Components/HoverZoomPan',
+    title: 'Components/Composites/HoverZoomPan',
     decorators: [
         (Story) => (
             <section

--- a/src/components/MomentumTabs.stories.tsx
+++ b/src/components/MomentumTabs.stories.tsx
@@ -12,7 +12,7 @@ type StoryArgs = {
 };
 
 const meta: Meta<StoryArgs> = {
-    title: 'Components/MomentumTabs',
+    title: 'Components/Composites/MomentumTabs',
     decorators: [
         (Story) => (
             <section

--- a/src/components/MomentumTabs.tsx
+++ b/src/components/MomentumTabs.tsx
@@ -59,8 +59,13 @@ const MomentumTabs = <T extends string>({
         transitionTimers.current = [];
     };
 
+    // Gated on `enabled` so we only measure once the parent signals the
+    // section is in view. Important when the parent has `content-visibility: auto`
+    // — without `enabled`, this effect would fire on first mount with a layout
+    // that's been skipped, yielding zero-width measurements that then get
+    // frozen by the initializedRef guard.
     useLayoutEffect(() => {
-        if (initializedRef.current) return;
+        if (initializedRef.current || !enabled) return;
         initializedRef.current = true;
         const el = buttonRefs.current[active];
         if (el) {
@@ -71,7 +76,7 @@ const MomentumTabs = <T extends string>({
                 height: el.offsetHeight
             });
         }
-    }, [active]);
+    }, [enabled, active]);
 
     // Initial wrap animation. Held until `enabled` flips to true (so the section
     // can defer it until scrolled into view). Fires exactly once.

--- a/src/components/NavBar.stories.tsx
+++ b/src/components/NavBar.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta } from '@storybook/react-vite';
 import NavBar from './NavBar';
 
 const meta: Meta<typeof NavBar> = {
-    title: 'Sections/NavBar',
+    title: 'Showcase/Sections/NavBar',
     component: NavBar,
     decorators: [
         (Story) => (

--- a/src/components/PreFooter.stories.tsx
+++ b/src/components/PreFooter.stories.tsx
@@ -3,7 +3,7 @@ import PreFooter from './PreFooter';
 import '../assets/styles/Footer.css';
 
 const meta: Meta<typeof PreFooter> = {
-    title: 'Components/PreFooter',
+    title: 'Components/Composites/PreFooter',
     component: PreFooter,
     decorators: [
         (Story) => (

--- a/src/components/ProjectCard.stories.tsx
+++ b/src/components/ProjectCard.stories.tsx
@@ -9,7 +9,7 @@ import cSolutions from '../assets/images/projects/c-solutions-512.png';
 import filthyFood from '../assets/images/projects/filthy-food-512.png';
 
 const meta: Meta<typeof ProjectCard> = {
-    title: 'Components/ProjectCard',
+    title: 'Components/Primitives/ProjectCard',
     component: ProjectCard,
     decorators: [
         (Story) => (

--- a/src/components/ProjectCardHoverExploration.stories.tsx
+++ b/src/components/ProjectCardHoverExploration.stories.tsx
@@ -175,7 +175,7 @@ const Tilt = () => (
 );
 
 const meta: Meta = {
-    title: 'Explorations/ProjectCardHover',
+    title: 'Process/ProjectCardHover',
     parameters: { layout: 'fullscreen' }
 };
 export default meta;

--- a/src/components/ProjectCardSkeleton.stories.tsx
+++ b/src/components/ProjectCardSkeleton.stories.tsx
@@ -4,7 +4,7 @@ import ProjectCardSkeleton from './ProjectCardSkeleton';
 import '../assets/styles/Projects.css';
 
 const meta: Meta<typeof ProjectCardSkeleton> = {
-    title: 'Components/ProjectCardSkeleton',
+    title: 'Components/Skeletons/ProjectCardSkeleton',
     component: ProjectCardSkeleton,
     decorators: [
         (Story) => (

--- a/src/components/ProjectList.stories.tsx
+++ b/src/components/ProjectList.stories.tsx
@@ -16,7 +16,7 @@ const sampleProjects = [
 ];
 
 const meta: Meta<typeof ProjectList> = {
-    title: 'Components/ProjectList',
+    title: 'Components/Composites/ProjectList',
     component: ProjectList,
     decorators: [
         (Story) => (

--- a/src/components/ProjectTabsExploration.stories.tsx
+++ b/src/components/ProjectTabsExploration.stories.tsx
@@ -594,7 +594,7 @@ const StackedSectionsVariant = () => (
 );
 
 const meta: Meta = {
-    title: 'Explorations/ProjectTabs',
+    title: 'Process/ProjectTabs',
     parameters: { layout: 'fullscreen' },
     /* Each variant relies on useLayoutEffect to measure tab buttons and
        paint the active indicator. When Storybook switches between variants

--- a/src/components/Projects.stories.tsx
+++ b/src/components/Projects.stories.tsx
@@ -18,7 +18,7 @@ import patternArchiveWizard from '../assets/images/projects/pattern-archive-wiza
 import patternArchiveLibrary from '../assets/images/projects/pattern-archive-library.png';
 
 const meta: Meta<typeof Projects> = {
-    title: 'Sections/Projects',
+    title: 'Showcase/Sections/Projects',
     component: Projects,
     parameters: { layout: 'fullscreen' }
 };

--- a/src/components/Skills.stories.tsx
+++ b/src/components/Skills.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta } from '@storybook/react-vite';
 import Skills from './Skills';
 
 const meta: Meta<typeof Skills> = {
-    title: 'Sections/Skills',
+    title: 'Showcase/Sections/Skills',
     component: Skills,
     decorators: [
         (Story) => (

--- a/src/components/SkillsCarousel.stories.tsx
+++ b/src/components/SkillsCarousel.stories.tsx
@@ -4,7 +4,7 @@ import '../assets/styles/Skills.css';
 import 'react-multi-carousel/lib/styles.css';
 
 const meta: Meta<typeof SkillsCarousel> = {
-    title: 'Components/SkillsCarousel',
+    title: 'Components/Composites/SkillsCarousel',
     component: SkillsCarousel,
     decorators: [
         // id="skills" is required by SkillsCarousel's keyboard-nav IntersectionObserver.

--- a/src/components/SocialIcons.stories.tsx
+++ b/src/components/SocialIcons.stories.tsx
@@ -12,7 +12,7 @@ import codecademyIcon from '../assets/images/icons/codecademy-icon.svg';
 import duolingoIcon from '../assets/images/icons/duolingo-icon.svg';
 
 const meta: Meta<typeof SocialIcons> = {
-    title: 'Components/SocialIcons',
+    title: 'Components/Primitives/SocialIcons',
     component: SocialIcons,
     decorators: [
         (Story) => (


### PR DESCRIPTION
## Summary

Phase 4 of the Storybook overhaul — adopts the `Showcase / Components / Process` taxonomy in one atomic rename pass. Locks in the sidebar shape so Phase 3 (autodocs + MDX) and Phase 5 (exploration narratives) write prose directly into the final structure.

### New IA

```
Showcase/
  Sections/
    Hero, Skills, Projects, ContactMe, NavBar, Footer
Components/
  Composites/
    HeroContent, SkillsCarousel, MomentumTabs, FeaturedProjectCard,
    FeaturedImageSlider, HoverZoomPan, ProjectList, ContactForm, PreFooter
  Primitives/
    ProjectCard, SocialIcons
  Skeletons/
    FeaturedProjectCardSkeleton, ProjectCardSkeleton
Process/
  BranchBeaconImage, FeaturedImageSlider, ProjectCardHover, ProjectTabs
```

Sidebar sort order configured in `.storybook/preview.js`:
- Showcase first (portfolio narrative — what visitors see)
- Components second (building blocks)
- Process last (design-process artifacts)

Sub-buckets within Components ordered: Composites → Primitives → Skeletons.

### Chromatic note

All story IDs change with the title rename, so Chromatic will report every story as "deleted" + "new" on this build. Expected — re-baseline at this commit.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build-storybook` succeeds
- [ ] Open Storybook locally — verify sidebar order matches the spec
- [ ] Run `npm run chromatic:baseline` after merge to lock in new IDs as baseline