### PR TITLE
feat: storybook IA polish + missing primitives + invalid state (#79)

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -20,13 +20,13 @@ const preview = {
 
     options: {
       // Showcase first (the portfolio narrative), Components second (the
-      // building blocks), Process last (the design-process artifacts).
+      // building blocks), Design Iterations last (the design-process artifacts).
       // Within each top-level bucket, sub-buckets and stories sort alphabetically.
       storySort: {
         order: [
           'Showcase', ['Sections'],
           'Components', ['Composites', 'Primitives', 'Skeletons'],
-          'Process'
+          'Design Iterations'
         ]
       }
     }

--- a/src/assets/styles/Contact.css
+++ b/src/assets/styles/Contact.css
@@ -89,16 +89,21 @@
 }
 
 .contact form input:user-invalid,
-.contact form textarea:user-invalid {
+.contact form textarea:user-invalid,
+.contact form input[aria-invalid="true"],
+.contact form textarea[aria-invalid="true"] {
     border-color: rgba(239, 68, 68, 0.95);
     background: rgba(239, 68, 68, 0.12);
     box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.45);
 }
 
 .contact form input:user-invalid:focus,
-.contact form textarea:user-invalid:focus {
+.contact form textarea:user-invalid:focus,
+.contact form input[aria-invalid="true"]:focus,
+.contact form textarea[aria-invalid="true"]:focus {
     background: rgba(255, 255, 255, 1);
     color: var(--dark-grey);
+    border-color: rgba(220, 38, 38, 1);
 }
 
 .contact form input:focus::placeholder, .contact form textarea:focus::placeholder {

--- a/src/assets/styles/Contact.css
+++ b/src/assets/styles/Contact.css
@@ -90,8 +90,9 @@
 
 .contact form input:user-invalid,
 .contact form textarea:user-invalid {
-    border-color: rgba(252, 165, 165, 0.7);
-    background: rgba(252, 165, 165, 0.08);
+    border-color: rgba(239, 68, 68, 0.95);
+    background: rgba(239, 68, 68, 0.12);
+    box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.45);
 }
 
 .contact form input:user-invalid:focus,

--- a/src/assets/styles/NavBar.css
+++ b/src/assets/styles/NavBar.css
@@ -89,16 +89,19 @@ span.navbar-text {
 }
 
 /* ==== Social Icons ==== */
-.social-icons a.social-icon {
+/* Scoped to nav.navbar so these overrides don't bleed into the Footer
+   or standalone Storybook usages of SocialIcons — without the scope,
+   `width: 45%` would stretch the icons globally once NavBar.css loads. */
+nav.navbar .social-icons a.social-icon {
   width: 45%;
   transition: all 0.3s ease-in-out;
 }
 
-.social-icons a.social-icon.twitter img {
+nav.navbar .social-icons a.social-icon.twitter img {
   width: 45%;
 }
 
-.social-icons a.social-icon.github img {
+nav.navbar .social-icons a.social-icon.github img {
   width: 50%;
   padding: 0.1em 0.1em 0 0;
 }

--- a/src/components/BranchBeaconImageExploration.stories.tsx
+++ b/src/components/BranchBeaconImageExploration.stories.tsx
@@ -13,7 +13,7 @@ type StoryArgs = {
 };
 
 const meta: Meta<StoryArgs> = {
-    title: 'Process/BranchBeaconImage',
+    title: 'Design Iterations/BranchBeaconImage',
     decorators: [
         (Story) => (
             <section

--- a/src/components/BranchBeaconImageExploration.stories.tsx
+++ b/src/components/BranchBeaconImageExploration.stories.tsx
@@ -28,7 +28,7 @@ const meta: Meta<StoryArgs> = {
             </section>
         )
     ],
-    parameters: { layout: 'fullscreen' },
+    parameters: { layout: 'fullscreen', docs: { description: { component: "Tuning the HoverZoomPan zoom multiplier and transition duration on the Branch Beacon card image." } } },
     argTypes: {
         zoomPercent: {
             control: { type: 'range', min: 100, max: 200, step: 1 },

--- a/src/components/ButtonPrimitive.stories.tsx
+++ b/src/components/ButtonPrimitive.stories.tsx
@@ -1,0 +1,208 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Col, Row } from 'react-bootstrap';
+import { ArrowRightCircle, FileEarmarkText } from 'react-bootstrap-icons';
+import '../assets/styles/Projects.css';
+import '../assets/styles/Contact.css';
+import '../assets/styles/NavBar.css';
+
+/* Story-only catalogue of the button-shaped primitives the live site
+   uses. Each story renders the same markup the consuming component
+   ships (matching className + parent selector chain) so the visual
+   matches production. Backlog issue #106 tracks promoting these into
+   reusable React components. */
+
+const meta: Meta = {
+    title: 'Components/Primitives/Button',
+    parameters: {
+        layout: 'centered',
+        docs: {
+            description: {
+                component:
+                    "Catalogue of every button-shaped primitive used in the live portfolio. Variants live under different parent selectors (`.contact form button`, `.btn-outline-secondary`, `.navbar-text .resume-button`), so each story wraps in the appropriate ancestor."
+            }
+        }
+    }
+};
+export default meta;
+
+type Story = StoryObj;
+
+const DarkBg = ({ children }: { children: React.ReactNode }) => (
+    <div style={{ background: 'var(--almost-black)', padding: '3rem' }}>
+        {children}
+    </div>
+);
+
+// --- 1. Outline secondary (project card action) --------------------
+export const OutlineSecondary: Story = {
+    render: () => (
+        <DarkBg>
+            <section
+                className="projects"
+                style={{ padding: 0, background: 'transparent' }}
+            >
+                <Row>
+                    <Col xs="auto">
+                        <div className="project-card">
+                            <a
+                                href="#"
+                                onClick={(e) => e.preventDefault()}
+                                className="btn btn-outline-secondary"
+                            >
+                                View Site
+                            </a>
+                        </div>
+                    </Col>
+                </Row>
+            </section>
+        </DarkBg>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "ProjectCard / FeaturedProjectCard action link. Markup is `<a className=\"btn btn-outline-secondary\">`, scoped under `.project-card`."
+            }
+        }
+    }
+};
+
+// --- 2. Outline secondary, disabled (locked private project) -------
+export const OutlineSecondaryDisabled: Story = {
+    render: () => (
+        <DarkBg>
+            <section
+                className="projects"
+                style={{ padding: 0, background: 'transparent' }}
+            >
+                <Row>
+                    <Col xs="auto">
+                        <div className="project-card">
+                            <span
+                                className="btn btn-outline-secondary featured-project-action--disabled"
+                                title="Private repository"
+                                aria-disabled="true"
+                            >
+                                Source Code
+                                <span
+                                    className="featured-project-action-lock"
+                                    aria-hidden
+                                >
+                                    🔒
+                                </span>
+                            </span>
+                        </div>
+                    </Col>
+                </Row>
+            </section>
+        </DarkBg>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Disabled variant rendered as a `<span aria-disabled>`. Used when a featured project's repo is private."
+            }
+        }
+    }
+};
+
+// --- 3. Hero CTA ("Let's Chat" with arrow) -------------------------
+// `.hero button` styles are replicated inline because the `.hero`
+// section adds a full-viewport cosmic background + overlay we don't
+// want here. The visual matches `.hero button` from Hero.css exactly.
+export const HeroCTA: Story = {
+    render: () => (
+        <DarkBg>
+            <button
+                onClick={(e) => e.preventDefault()}
+                style={{
+                    background: 'none',
+                    border: 'none',
+                    color: 'var(--font-color)',
+                    fontWeight: 700,
+                    fontSize: 20,
+                    letterSpacing: '0.8px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    transition: 'all 0.3s ease-in-out',
+                    cursor: 'pointer'
+                }}
+            >
+                Let&apos;s Chat
+                <ArrowRightCircle size={25} style={{ marginLeft: 10 }} />
+            </button>
+        </DarkBg>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Hero section call-to-action. Transparent button, bold white text, ArrowRightCircle icon. The arrow rotates 90° on hover in the live `.hero button:hover svg` rule."
+            }
+        }
+    }
+};
+
+// --- 4. Submit button (contact form) -------------------------------
+export const ContactSubmit: Story = {
+    render: () => (
+        <section
+            className="contact"
+            style={{
+                background:
+                    'linear-gradient(90deg, #5b2a86 0%, #4a6fc7 100%)',
+                padding: '3rem'
+            }}
+        >
+            <form onSubmit={(e) => e.preventDefault()}>
+                <div className="submit-container">
+                    <button type="submit">
+                        <span>Send</span>
+                    </button>
+                </div>
+            </form>
+        </section>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Contact-form submit button. Hover swaps to a dark fill via a `::before` pseudo-element."
+            }
+        }
+    }
+};
+
+// --- 5. Resume button (nav bar) ------------------------------------
+// The `position: relative; zIndex: 0` on the wrapping span establishes
+// a local stacking context so the button's `::before` (z-index: -1)
+// stays behind the button content but in front of the page bg —
+// matching how the live `nav.navbar` (z-index: 9999) provides this
+// in production.
+export const ResumeNavButton: Story = {
+    render: () => (
+        <DarkBg>
+            <span
+                className="navbar-text"
+                style={{ position: 'relative', zIndex: 0 }}
+            >
+                <button
+                    className="resume-button"
+                    onClick={(e) => e.preventDefault()}
+                >
+                    <FileEarmarkText size={20} className="me-2" />
+                    <span>My Resume</span>
+                </button>
+            </span>
+        </DarkBg>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Resume-download button on the right side of the nav bar. White outline, gradient fill animates in from the left on hover via a `::before` pseudo-element."
+            }
+        }
+    }
+};

--- a/src/components/ContactForm.stories.tsx
+++ b/src/components/ContactForm.stories.tsx
@@ -24,7 +24,7 @@ const meta: Meta<typeof ContactForm> = {
             </section>
         )
     ],
-    parameters: { layout: 'fullscreen' }
+    parameters: { layout: 'fullscreen', docs: { description: { component: "The contact form proper — five fields, honeypot spam protection, staged success / error animations, and a `VITE_MOCK_FORM` dev mock." } } }
 };
 
 export default meta;

--- a/src/components/ContactMe.stories.tsx
+++ b/src/components/ContactMe.stories.tsx
@@ -3,7 +3,7 @@ import ContactMe from './ContactMe';
 const meta = {
     title: 'Showcase/Sections/ContactMe',
     component: ContactMe,
-    parameters: { layout: 'fullscreen' }
+    parameters: { layout: 'fullscreen', docs: { description: { component: "The Contact section — a Web3Forms-backed contact form with staged success/error animations and a side-rail social icon column." } } }
 };
 
 export default meta;

--- a/src/components/FeaturedImageSlider.stories.tsx
+++ b/src/components/FeaturedImageSlider.stories.tsx
@@ -49,7 +49,7 @@ const meta: Meta<StoryArgs> = {
             </section>
         )
     ],
-    parameters: { layout: 'fullscreen' },
+    parameters: { layout: 'fullscreen', docs: { description: { component: "Auto-advancing image slider with hover-pause, optional click-to-lightbox, arrow / keyboard / swipe controls, and four indicator variants." } } },
     argTypes: {
         images: {
             control: { type: 'object' },

--- a/src/components/FeaturedImageSliderExploration.stories.tsx
+++ b/src/components/FeaturedImageSliderExploration.stories.tsx
@@ -21,7 +21,7 @@ type StoryArgs = {
 };
 
 const meta: Meta<StoryArgs> = {
-    title: 'Process/FeaturedImageSlider',
+    title: 'Design Iterations/FeaturedImageSlider',
     decorators: [
         (Story) => (
             <section

--- a/src/components/FeaturedImageSliderExploration.stories.tsx
+++ b/src/components/FeaturedImageSliderExploration.stories.tsx
@@ -36,7 +36,7 @@ const meta: Meta<StoryArgs> = {
             </section>
         )
     ],
-    parameters: { layout: 'fullscreen' },
+    parameters: { layout: 'fullscreen', docs: { description: { component: "Comparison of indicator and control variants for the FeaturedImageSlider before the production combination landed." } } },
     argTypes: {
         indicator: {
             control: { type: 'radio' },

--- a/src/components/FeaturedProjectCard.stories.tsx
+++ b/src/components/FeaturedProjectCard.stories.tsx
@@ -27,7 +27,7 @@ const meta: Meta<typeof FeaturedProjectCard> = {
             </section>
         )
     ],
-    parameters: { layout: 'fullscreen' },
+    parameters: { layout: 'fullscreen', docs: { description: { component: "The card layout used in the Featured + Personal Projects tabs. Renders a title, subtitle, description, tech stack chips, an image slot, and action buttons." } } },
     argTypes: {
         title: {
             control: { type: 'text' },

--- a/src/components/FeaturedProjectCardSkeleton.stories.tsx
+++ b/src/components/FeaturedProjectCardSkeleton.stories.tsx
@@ -20,7 +20,7 @@ const meta: Meta<typeof FeaturedProjectCardSkeleton> = {
             </section>
         )
     ],
-    parameters: { layout: 'fullscreen' }
+    parameters: { layout: 'fullscreen', docs: { description: { component: "Loading-state placeholder matching the FeaturedProjectCard layout." } } }
 };
 
 export default meta;

--- a/src/components/Footer.stories.tsx
+++ b/src/components/Footer.stories.tsx
@@ -3,7 +3,7 @@ import Footer from './Footer';
 const meta = {
     title: 'Showcase/Sections/Footer',
     component: Footer,
-    parameters: { layout: 'fullscreen' }
+    parameters: { layout: 'fullscreen', docs: { description: { component: "Page footer — built-with attribution + social icons + copyright. Sits below PreFooter on the live site." } } }
 };
 
 export default meta;

--- a/src/components/Hero.stories.tsx
+++ b/src/components/Hero.stories.tsx
@@ -3,7 +3,7 @@ import Hero from './Hero';
 const meta = {
     title: 'Showcase/Sections/Hero',
     component: Hero,
-    parameters: { layout: 'fullscreen' }
+    parameters: { layout: 'fullscreen', docs: { description: { component: "The hero section that opens the portfolio. Full-bleed background with bitmoji illustration and an animated typing CTA." } } }
 };
 
 export default meta;

--- a/src/components/HeroContent.stories.tsx
+++ b/src/components/HeroContent.stories.tsx
@@ -37,7 +37,7 @@ const meta: Meta<typeof HeroContent> = {
             </section>
         )
     ],
-    parameters: { layout: 'fullscreen' }
+    parameters: { layout: 'fullscreen', docs: { description: { component: "The text + CTA block inside Hero. Drives the typing-effect headline cycle." } } }
 };
 
 export default meta;

--- a/src/components/HoverZoomPan.stories.tsx
+++ b/src/components/HoverZoomPan.stories.tsx
@@ -33,7 +33,7 @@ const meta: Meta<StoryArgs> = {
             </section>
         )
     ],
-    parameters: { layout: 'fullscreen' },
+    parameters: { layout: 'fullscreen', docs: { description: { component: "Image with mouse-driven zoom-and-pan on hover. Cursor position drives the transform-origin so the image pans toward the area under the cursor." } } },
     argTypes: {
         src: { table: { disable: true } },
         alt: { control: { type: 'text' } },

--- a/src/components/InputPrimitive.stories.tsx
+++ b/src/components/InputPrimitive.stories.tsx
@@ -1,0 +1,230 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within } from 'storybook/test';
+import { Col, Row } from 'react-bootstrap';
+import '../assets/styles/Contact.css';
+
+/* Story-only catalogue of the form-field primitives used in
+   ContactForm. Selector chain `.contact form input` / `.contact form
+   textarea` so each story wraps in `<section class="contact"><form>`.
+   Backlog issue #106 tracks promoting these into reusable components. */
+
+const meta: Meta = {
+    title: 'Components/Primitives/Input',
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    "Frosted-glass form fields used in the contact section. Inputs and textarea share the same styling — white-on-blur focus state, semi-transparent background, salmon-tinted invalid border (`:user-invalid`)."
+            }
+        }
+    },
+    decorators: [
+        (Story) => (
+            <section
+                className="contact"
+                style={{
+                    background:
+                        'linear-gradient(90deg, #5b2a86 0%, #4a6fc7 100%)',
+                    padding: '3rem',
+                    minHeight: '300px'
+                }}
+            >
+                <form
+                    onSubmit={(e) => e.preventDefault()}
+                    style={{ maxWidth: 600, margin: '0 auto' }}
+                    noValidate={false}
+                >
+                    <Story />
+                </form>
+            </section>
+        )
+    ]
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const Default: Story = {
+    render: () => (
+        <Row>
+            <Col className="px-1" sm={12}>
+                <input
+                    type="text"
+                    name="firstName"
+                    placeholder="First Name *"
+                    aria-label="First Name (required)"
+                    autoComplete="given-name"
+                    required
+                />
+            </Col>
+        </Row>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Idle input. Placeholder doubles as the visible label; semi-transparent white background; pale border."
+            }
+        }
+    }
+};
+
+export const Filled: Story = {
+    render: () => (
+        <Row>
+            <Col className="px-1" sm={6}>
+                <input
+                    type="text"
+                    name="firstName"
+                    defaultValue="Miguel"
+                    placeholder="First Name *"
+                    aria-label="First Name (required)"
+                    required
+                />
+            </Col>
+            <Col className="px-1" sm={6}>
+                <input
+                    type="email"
+                    name="email"
+                    defaultValue="miguel@example.com"
+                    placeholder="Email Address *"
+                    aria-label="Email Address (required)"
+                    required
+                />
+            </Col>
+            <Col className="px-1" sm={12}>
+                <textarea
+                    name="message"
+                    rows={4}
+                    defaultValue="Loved your portfolio — let's chat about a senior frontend role."
+                    placeholder="Message *"
+                    aria-label="Message (required)"
+                    required
+                />
+            </Col>
+        </Row>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Inputs with values. Side-by-side text + email + textarea so the typography and value rendering can be reviewed at a glance."
+            }
+        }
+    }
+};
+
+// `:focus` styles only paint while the input is the active element, so
+// the play function focuses it on mount.
+export const Focused: Story = {
+    render: () => (
+        <Row>
+            <Col className="px-1" sm={12}>
+                <input
+                    type="text"
+                    name="firstName"
+                    placeholder="First Name *"
+                    aria-label="First Name (required)"
+                    required
+                />
+            </Col>
+        </Row>
+    ),
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        canvas.getByPlaceholderText(/First Name/i).focus();
+    },
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Focus state. Background flips to solid white, dark text, inset shadow rim; placeholder dims."
+            }
+        }
+    }
+};
+
+// `aria-invalid="true"` drives the same red styling as `:user-invalid`
+// (the CSS rule keys off both), but is deterministic in stories — it
+// doesn't depend on synthetic blur events triggering the pseudo-class.
+export const Invalid: Story = {
+    render: () => (
+        <Row>
+            <Col className="px-1" sm={12}>
+                <input
+                    type="email"
+                    name="email"
+                    defaultValue="not-an-email"
+                    placeholder="Email Address *"
+                    aria-label="Email Address (required)"
+                    aria-invalid="true"
+                    required
+                />
+            </Col>
+        </Row>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Invalid state. Red border, faint red background fill, outer red ring. Driven by `aria-invalid=\"true\"` here; in production the same styling fires on `:user-invalid` after the user enters a bad value and blurs."
+            }
+        }
+    }
+};
+
+export const InvalidFocused: Story = {
+    render: () => (
+        <Row>
+            <Col className="px-1" sm={12}>
+                <input
+                    type="email"
+                    name="email"
+                    defaultValue="not-an-email"
+                    placeholder="Email Address *"
+                    aria-label="Email Address (required)"
+                    aria-invalid="true"
+                    required
+                />
+            </Col>
+        </Row>
+    ),
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        canvas.getByPlaceholderText(/Email Address/i).focus();
+    },
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Invalid + focused. Background flips to solid white and text turns dark (focus styling), but the red border remains so the error stays visible while the user edits."
+            }
+        }
+    }
+};
+
+export const Textarea: Story = {
+    render: () => (
+        <Row>
+            <Col className="px-1" sm={12}>
+                <textarea
+                    name="message"
+                    rows={6}
+                    placeholder="Message *"
+                    aria-label="Message (required)"
+                    autoComplete="off"
+                    required
+                />
+            </Col>
+        </Row>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Multiline message textarea. Inherits the same `.contact form input, .contact form textarea` ruleset — including focus and invalid states."
+            }
+        }
+    }
+};

--- a/src/components/MomentumTabs.stories.tsx
+++ b/src/components/MomentumTabs.stories.tsx
@@ -27,7 +27,7 @@ const meta: Meta<StoryArgs> = {
             </section>
         )
     ],
-    parameters: { layout: 'fullscreen' },
+    parameters: { layout: 'fullscreen', docs: { description: { component: "Animated tab indicator that wraps the active tab with a perimeter trace. Initial wrap animation gates on `enabled` (parent's IntersectionObserver) so it reveals as the user scrolls into view." } } },
     argTypes: {
         tabs: {
             control: { type: 'object' },

--- a/src/components/NavBar.stories.tsx
+++ b/src/components/NavBar.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof NavBar> = {
             </div>
         )
     ],
-    parameters: { layout: 'fullscreen' }
+    parameters: { layout: 'fullscreen', docs: { description: { component: "Fixed navigation bar that scroll-spies the active section. Collapses to a hamburger on smaller viewports." } } }
 };
 
 export default meta;

--- a/src/components/NavLinkPrimitive.stories.tsx
+++ b/src/components/NavLinkPrimitive.stories.tsx
@@ -1,0 +1,123 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../assets/styles/NavBar.css';
+
+/* Story-only catalogue of the nav-link primitive used inside the
+   navbar. Selector chain is `nav.navbar .navbar-nav .nav-link.navbar-link`,
+   so each story wraps in `<nav class="navbar"><div class="navbar-nav">`
+   for the styles to apply. Backlog issue #106 tracks promoting this
+   into a reusable component. */
+
+const meta: Meta = {
+    title: 'Components/Primitives/NavLink',
+    parameters: {
+        layout: 'centered',
+        docs: {
+            description: {
+                component:
+                    "Top-level nav link rendered in the NavBar. Three meaningful states: idle (60% opacity), hover (100% opacity), active (100% opacity, identical visual to hover)."
+            }
+        }
+    },
+    decorators: [
+        (Story) => (
+            <nav
+                className="navbar"
+                style={{
+                    background: 'var(--almost-black)',
+                    padding: '1.5rem 2rem',
+                    position: 'static'
+                }}
+            >
+                <div className="navbar-nav" style={{ flexDirection: 'row' }}>
+                    <Story />
+                </div>
+            </nav>
+        )
+    ]
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const Idle: Story = {
+    render: () => (
+        <a
+            href="#"
+            onClick={(e) => e.preventDefault()}
+            className="nav-link navbar-link"
+        >
+            Home
+        </a>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Inactive link. White text at 60% opacity."
+            }
+        }
+    }
+};
+
+export const Active: Story = {
+    render: () => (
+        <a
+            href="#"
+            onClick={(e) => e.preventDefault()}
+            className="nav-link navbar-link active"
+        >
+            Projects
+        </a>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Active link — applied by the section-tracker on the link whose section is currently in viewport. Opacity goes to 100%."
+            }
+        }
+    }
+};
+
+export const FullRow: Story = {
+    render: () => (
+        <>
+            <a
+                href="#"
+                onClick={(e) => e.preventDefault()}
+                className="nav-link navbar-link active"
+            >
+                Home
+            </a>
+            <a
+                href="#"
+                onClick={(e) => e.preventDefault()}
+                className="nav-link navbar-link"
+            >
+                Skills
+            </a>
+            <a
+                href="#"
+                onClick={(e) => e.preventDefault()}
+                className="nav-link navbar-link"
+            >
+                Projects
+            </a>
+            <a
+                href="#"
+                onClick={(e) => e.preventDefault()}
+                className="nav-link navbar-link"
+            >
+                Contact
+            </a>
+        </>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "All four nav links side-by-side. Live navbar shows them at 18px on desktop and 3em on the mobile collapsed menu."
+            }
+        }
+    }
+};

--- a/src/components/PreFooter.stories.tsx
+++ b/src/components/PreFooter.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta<typeof PreFooter> = {
             </footer>
         )
     ],
-    parameters: { layout: 'fullscreen' }
+    parameters: { layout: 'fullscreen', docs: { description: { component: "The 'Built With' attribution block that sits between the page content and the Footer. Has a negative top margin to overlap into the section above on the live site." } } }
 };
 
 export default meta;

--- a/src/components/ProjectCard.stories.tsx
+++ b/src/components/ProjectCard.stories.tsx
@@ -23,9 +23,7 @@ const meta: Meta<typeof ProjectCard> = {
             </section>
         )
     ],
-    parameters: {
-        layout: 'fullscreen'
-    },
+    parameters: { layout: 'fullscreen', docs: { description: { component: "Single card used in the Client Projects grid. Shows an image with a hover overlay revealing title + description + view-site button." } } },
     argTypes: {
         title: { control: { type: 'text' }, description: 'Project name' },
         description: { control: { type: 'text' }, description: 'Short tagline' },

--- a/src/components/ProjectCardHoverExploration.stories.css
+++ b/src/components/ProjectCardHoverExploration.stories.css
@@ -1,6 +1,7 @@
 /* Shared base for all hover-exploration cards. Width is driven by the parent
    Bootstrap Col (sm=6 md=4) so each variant renders at exactly the same width
-   as the live ProjectCard. Aspect-ratio: 1/1 enforces the square shape. */
+   as the live ProjectCard. Aspect-ratio 8/5 matches the source image's natural
+   proportions (the live ProjectCard inherits this from the unconstrained img). */
 .hv-card {
     display: block;
     width: 100%;
@@ -30,7 +31,7 @@
     position: relative;
     border-radius: 0.6em;
     overflow: hidden;
-    aspect-ratio: 1 / 1;
+    aspect-ratio: 8 / 5;
 }
 
 .hv-card--current img {
@@ -78,7 +79,7 @@
     border-radius: 0.6em;
     overflow: hidden;
     position: relative;
-    aspect-ratio: 1 / 1;
+    aspect-ratio: 8 / 5;
 }
 
 .hv-zoom__image-wrap {
@@ -126,7 +127,7 @@
     position: relative;
     border-radius: 0.6em;
     overflow: hidden;
-    aspect-ratio: 1 / 1;
+    aspect-ratio: 8 / 5;
     transition: transform 0.35s cubic-bezier(0.2, 0, 0.2, 1), box-shadow 0.35s ease;
     box-shadow: 0 0 0 transparent;
 }
@@ -170,7 +171,7 @@
     position: relative;
     border-radius: 0.6em;
     overflow: hidden;
-    aspect-ratio: 1 / 1;
+    aspect-ratio: 8 / 5;
 }
 
 .hv-card--glass img {
@@ -204,7 +205,7 @@
     padding: 2px;
     border-radius: 0.65em;
     transition: transform 0.35s ease;
-    aspect-ratio: 1 / 1;
+    aspect-ratio: 8 / 5;
 }
 
 .hv-border__glow {
@@ -268,7 +269,7 @@
     position: relative;
     border-radius: 0.6em;
     overflow: hidden;
-    aspect-ratio: 1 / 1;
+    aspect-ratio: 8 / 5;
 }
 
 .hv-card--gs img {
@@ -310,7 +311,7 @@
     position: relative;
     border-radius: 0.6em;
     overflow: hidden;
-    aspect-ratio: 1 / 1;
+    aspect-ratio: 8 / 5;
 }
 
 .hv-card--sweep img {
@@ -360,7 +361,7 @@
     position: relative;
     border-radius: 0.6em;
     overflow: hidden;
-    aspect-ratio: 1 / 1;
+    aspect-ratio: 8 / 5;
 }
 
 .hv-kb__image-wrap {
@@ -408,7 +409,7 @@
 .hv-card--tilt {
     position: relative;
     perspective: 1000px;
-    aspect-ratio: 1 / 1;
+    aspect-ratio: 8 / 5;
 }
 
 .hv-tilt__plane {

--- a/src/components/ProjectCardHoverExploration.stories.tsx
+++ b/src/components/ProjectCardHoverExploration.stories.tsx
@@ -175,7 +175,7 @@ const Tilt = () => (
 );
 
 const meta: Meta = {
-    title: 'Process/ProjectCardHover',
+    title: 'Design Iterations/ProjectCardHover',
     parameters: { layout: 'fullscreen', docs: { description: { component: "Side-by-side comparison of nine hover-reveal effects considered for the ProjectCard before the chosen approach landed." } } }
 };
 export default meta;

--- a/src/components/ProjectCardHoverExploration.stories.tsx
+++ b/src/components/ProjectCardHoverExploration.stories.tsx
@@ -176,7 +176,7 @@ const Tilt = () => (
 
 const meta: Meta = {
     title: 'Process/ProjectCardHover',
-    parameters: { layout: 'fullscreen' }
+    parameters: { layout: 'fullscreen', docs: { description: { component: "Side-by-side comparison of nine hover-reveal effects considered for the ProjectCard before the chosen approach landed." } } }
 };
 export default meta;
 

--- a/src/components/ProjectCardSkeleton.stories.tsx
+++ b/src/components/ProjectCardSkeleton.stories.tsx
@@ -20,7 +20,7 @@ const meta: Meta<typeof ProjectCardSkeleton> = {
             </section>
         )
     ],
-    parameters: { layout: 'fullscreen' },
+    parameters: { layout: 'fullscreen', docs: { description: { component: "Loading-state placeholder matching the ProjectCard layout." } } },
     argTypes: {
         md: {
             control: { type: 'number', min: 2, max: 12, step: 1 },

--- a/src/components/ProjectList.stories.tsx
+++ b/src/components/ProjectList.stories.tsx
@@ -32,7 +32,7 @@ const meta: Meta<typeof ProjectList> = {
             </section>
         )
     ],
-    parameters: { layout: 'fullscreen' },
+    parameters: { layout: 'fullscreen', docs: { description: { component: "Grid of basic project cards. Used in the Client Projects tab." } } },
     argTypes: {
         projects: {
             control: { type: 'object' },

--- a/src/components/ProjectTabsExploration.stories.tsx
+++ b/src/components/ProjectTabsExploration.stories.tsx
@@ -595,7 +595,7 @@ const StackedSectionsVariant = () => (
 
 const meta: Meta = {
     title: 'Process/ProjectTabs',
-    parameters: { layout: 'fullscreen' },
+    parameters: { layout: 'fullscreen', docs: { description: { component: "Five tab-indicator approaches compared side by side before MomentumTabs (the perimeter-trace approach) won." } } },
     /* Each variant relies on useLayoutEffect to measure tab buttons and
        paint the active indicator. When Storybook switches between variants
        in this same file, React reuses the subtree and the measurement

--- a/src/components/ProjectTabsExploration.stories.tsx
+++ b/src/components/ProjectTabsExploration.stories.tsx
@@ -594,7 +594,7 @@ const StackedSectionsVariant = () => (
 );
 
 const meta: Meta = {
-    title: 'Process/ProjectTabs',
+    title: 'Design Iterations/ProjectTabs',
     parameters: { layout: 'fullscreen', docs: { description: { component: "Five tab-indicator approaches compared side by side before MomentumTabs (the perimeter-trace approach) won." } } },
     /* Each variant relies on useLayoutEffect to measure tab buttons and
        paint the active indicator. When Storybook switches between variants

--- a/src/components/Projects.stories.tsx
+++ b/src/components/Projects.stories.tsx
@@ -20,7 +20,7 @@ import patternArchiveLibrary from '../assets/images/projects/pattern-archive-lib
 const meta: Meta<typeof Projects> = {
     title: 'Showcase/Sections/Projects',
     component: Projects,
-    parameters: { layout: 'fullscreen' }
+    parameters: { layout: 'fullscreen', docs: { description: { component: "The Projects section — three tabs (Featured, Personal, Client) with animated transitions. Clicking a tab slides the active content out and the new content in." } } }
 };
 
 export default meta;

--- a/src/components/Skills.stories.tsx
+++ b/src/components/Skills.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof Skills> = {
             </div>
         )
     ],
-    parameters: { layout: 'fullscreen' }
+    parameters: { layout: 'fullscreen', docs: { description: { component: "The Skills section — a horizontal carousel of devicon glyphs that the visitor can scroll with arrow keys when the section is in view." } } }
 };
 
 export default meta;

--- a/src/components/SkillsCarousel.stories.tsx
+++ b/src/components/SkillsCarousel.stories.tsx
@@ -23,7 +23,7 @@ const meta: Meta<typeof SkillsCarousel> = {
             </section>
         )
     ],
-    parameters: { layout: 'fullscreen' }
+    parameters: { layout: 'fullscreen', docs: { description: { component: "Skills horizontal carousel. Custom-handles the TypeScript icon's white-square pseudo-element backdrop and pauses autoplay when off-screen." } } }
 };
 
 export default meta;

--- a/src/components/SliderControlsPrimitive.stories.tsx
+++ b/src/components/SliderControlsPrimitive.stories.tsx
@@ -1,0 +1,183 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../assets/styles/FeaturedImageSlider.css';
+
+/* Story-only catalogue of the slider control primitives — arrows and
+   the three indicator-dot variants — used inside FeaturedImageSlider.
+   Selectors are tightly coupled (`.featured-image-slider__dots--frosted
+   .featured-image-slider__dot`), so each story renders the matching
+   parent + child markup with `is-active` baked in for one item.
+   Backlog issue #106 tracks promoting these into reusable components. */
+
+const meta: Meta = {
+    title: 'Components/Primitives/SliderControls',
+    parameters: {
+        layout: 'centered',
+        docs: {
+            description: {
+                component:
+                    "Controls used by FeaturedImageSlider: previous/next arrows and the three dot-indicator variants (frosted, outlined, segmented progress)."
+            }
+        }
+    },
+    decorators: [
+        (Story) => (
+            <div
+                style={{
+                    background: 'var(--almost-black)',
+                    padding: '3rem'
+                }}
+            >
+                <Story />
+            </div>
+        )
+    ]
+};
+export default meta;
+
+type Story = StoryObj;
+
+// Carrier mimics the actual slide area so dots/arrows have a parent of
+// known size to anchor against. Width is fixed in px so the centered
+// layout stays predictable.
+const SliderShell = ({ children }: { children: React.ReactNode }) => (
+    <div
+        className="featured-image-slider"
+        style={{
+            position: 'relative',
+            width: 360,
+            height: 202,
+            background:
+                'linear-gradient(131deg, #AA367C 28%, #4A2FBD 71%)',
+            borderRadius: '0.6em',
+            overflow: 'hidden'
+        }}
+    >
+        {children}
+    </div>
+);
+
+export const Arrows: Story = {
+    render: () => (
+        <SliderShell>
+            {/* Force opacity: 1 — live arrows hide until the slider is
+                hovered, but the story should always show them. */}
+            <button
+                type="button"
+                aria-label="Previous image"
+                className="featured-image-slider__arrow featured-image-slider__arrow--prev"
+                style={{ opacity: 1 }}
+                onClick={(e) => e.preventDefault()}
+            >
+                <span aria-hidden>‹</span>
+            </button>
+            <button
+                type="button"
+                aria-label="Next image"
+                className="featured-image-slider__arrow featured-image-slider__arrow--next"
+                style={{ opacity: 1 }}
+                onClick={(e) => e.preventDefault()}
+            >
+                <span aria-hidden>›</span>
+            </button>
+        </SliderShell>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Prev / next arrow buttons. Live behavior fades them in on `:hover` of the slider; this story forces `opacity: 1` so they render standalone."
+            }
+        }
+    }
+};
+
+const Dots = ({
+    variant,
+    activeIndex = 1,
+    count = 3
+}: {
+    variant: 'frosted' | 'outlined';
+    activeIndex?: number;
+    count?: number;
+}) => (
+    <SliderShell>
+        <div
+            className={`featured-image-slider__dots featured-image-slider__dots--${variant}`}
+            role="tablist"
+        >
+            {Array.from({ length: count }).map((_, i) => (
+                <button
+                    key={i}
+                    type="button"
+                    role="tab"
+                    aria-label={`Show image ${i + 1}`}
+                    aria-selected={i === activeIndex}
+                    className={`featured-image-slider__dot ${
+                        i === activeIndex ? 'is-active' : ''
+                    }`}
+                    onClick={(e) => e.preventDefault()}
+                />
+            ))}
+        </div>
+    </SliderShell>
+);
+
+export const FrostedDots: Story = {
+    render: () => <Dots variant="frosted" />,
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Default indicator. Semi-transparent white circles with a backdrop-blur; active dot is fully opaque."
+            }
+        }
+    }
+};
+
+export const OutlinedDots: Story = {
+    render: () => <Dots variant="outlined" />,
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Outlined variant. White-bg dots with a dark ring; active dot gets a colored fill."
+            }
+        }
+    }
+};
+
+export const SegmentedProgress: Story = {
+    render: () => (
+        <SliderShell>
+            <div
+                className="featured-image-slider__segments"
+                role="tablist"
+            >
+                {[1, 0.6, 0].map((fill, i) => (
+                    <button
+                        key={i}
+                        type="button"
+                        role="tab"
+                        aria-label={`Show image ${i + 1}`}
+                        aria-selected={i === 1}
+                        className="featured-image-slider__segment"
+                        onClick={(e) => e.preventDefault()}
+                    >
+                        <span
+                            className="featured-image-slider__segment-fill"
+                            style={{ width: `${fill * 100}%` }}
+                        />
+                    </button>
+                ))}
+            </div>
+        </SliderShell>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Horizontal segmented bars that fill left-to-right as autoplay progresses. Frozen here at: completed, mid-fill, empty."
+            }
+        }
+    }
+};

--- a/src/components/SocialIcons.stories.tsx
+++ b/src/components/SocialIcons.stories.tsx
@@ -30,7 +30,8 @@ const meta: Meta<typeof SocialIcons> = {
             action: 'iconHover',
             description: 'Fires on per-icon hover with the icon label'
         }
-    }
+    },
+    parameters: { docs: { description: { component: "Row of social media link icons used in NavBar (top), Footer (bottom-left), and ContactMe (side rail). Optional `onHover` callback fires the icon label." } } }
 };
 
 export default meta;

--- a/src/components/StatusMessagePrimitive.stories.tsx
+++ b/src/components/StatusMessagePrimitive.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../assets/styles/Contact.css';
+
+/* Story-only catalogue of the inline form status message used by
+   ContactForm post-submit. Two states: success (envelope icon) and
+   danger (sweaty-smile error icon). The 0.7s entrance animation only
+   plays on first render, so refresh the story in Storybook to replay.
+   Backlog issue #106 tracks promoting this into a reusable component. */
+
+const meta: Meta = {
+    title: 'Components/Primitives/ContactFormStatus',
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    "Inline status banner shown after a **contact-form** submit attempt. Markup lives at `.contact form .form-status-message.{success,danger}` — the styling is contact-form-specific, not a generic status badge."
+            }
+        }
+    },
+    decorators: [
+        (Story) => (
+            <section
+                className="contact"
+                style={{
+                    background:
+                        'linear-gradient(90deg, #5b2a86 0%, #4a6fc7 100%)',
+                    padding: '3rem',
+                    minHeight: '300px'
+                }}
+            >
+                <form
+                    onSubmit={(e) => e.preventDefault()}
+                    style={{ maxWidth: 600, margin: '0 auto' }}
+                >
+                    <div className="submit-container">
+                        <Story />
+                    </div>
+                </form>
+            </section>
+        )
+    ]
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const Success: Story = {
+    render: () => (
+        <div
+            className="form-status-message success"
+            role="status"
+            aria-live="polite"
+        >
+            <span className="envelope-icon" aria-hidden="true">
+                {'\u{1F4E8}'}
+            </span>
+            <p>Thanks for reaching out — I&apos;ll get back to you shortly.</p>
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Happy-path confirmation. Envelope emoji slides in, message fades up. Reduced-motion users get the static state."
+            }
+        }
+    }
+};
+
+export const Error: Story = {
+    render: () => (
+        <div
+            className="form-status-message danger"
+            role="status"
+            aria-live="polite"
+        >
+            <span className="error-icon" aria-hidden="true">
+                {'\u{1F605}'}
+            </span>
+            <p>Oops! Request failed — please try again.</p>
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Failure path. Same animation timeline as Success, swapped icon and palette."
+            }
+        }
+    }
+};

--- a/src/components/TaglineBadgePrimitive.stories.tsx
+++ b/src/components/TaglineBadgePrimitive.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+/* Story-only catalogue of the tagline badge — the gradient-bg pill that
+   appears above the headline in the hero ("Welcome to my Portfolio").
+   `.hero .content .tagline` is the live selector chain, but the styles
+   are inlined here to avoid pulling in the `.hero` cosmic background.
+   Backlog issue #106 tracks promoting this into a reusable component. */
+
+const meta: Meta = {
+    title: 'Components/Primitives/TaglineBadge',
+    parameters: {
+        layout: 'centered',
+        docs: {
+            description: {
+                component:
+                    "The gradient-tinted pill above the hero headline. Uses the brand pink→purple gradient at 50% alpha with a subtle white border."
+            }
+        }
+    },
+    decorators: [
+        (Story) => (
+            <div
+                style={{
+                    background: 'var(--almost-black)',
+                    padding: '3rem',
+                    minWidth: 360
+                }}
+            >
+                <Story />
+            </div>
+        )
+    ]
+};
+export default meta;
+
+type Story = StoryObj;
+
+const taglineStyle: React.CSSProperties = {
+    display: 'inline-block',
+    background:
+        'linear-gradient(90.21deg, rgba(170, 54, 124, 0.5) -5.91%, rgba(74, 47, 189, 0.5) 111.58%)',
+    border: '1px solid rgba(255, 255, 255, 0.5)',
+    fontSize: 16,
+    fontWeight: 700,
+    letterSpacing: '0.8px',
+    padding: '8px 10px',
+    color: 'var(--font-color)',
+    transition: 'all 0.3s ease-in-out'
+};
+
+export const Default: Story = {
+    render: () => <span style={taglineStyle}>Welcome to my Portfolio</span>,
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Live tagline string. Inline-block with brand-gradient bg at 50% alpha, white-50 border, bold uppercase-feeling type."
+            }
+        }
+    }
+};
+
+export const ShortLabel: Story = {
+    render: () => <span style={taglineStyle}>Senior Frontend</span>,
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Shorter copy — confirms the badge sizes to its content rather than stretching."
+            }
+        }
+    }
+};
+
+export const LongLabel: Story = {
+    render: () => (
+        <span style={taglineStyle}>
+            Senior Frontend Engineer · Open to remote roles
+        </span>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Longer copy — single-line by default; would wrap if forced inside a constrained column."
+            }
+        }
+    }
+};

--- a/src/components/TechStackChipPrimitive.stories.tsx
+++ b/src/components/TechStackChipPrimitive.stories.tsx
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../assets/styles/Projects.css';
+
+/* Story-only catalogue of the tech-stack chip used in
+   FeaturedProjectCard. Selector chain is `.featured-project-stack li`,
+   so each story renders a `<ul class="featured-project-stack">` parent
+   with one or more `<li>` items. Backlog issue #106 tracks promoting
+   this into a reusable component. */
+
+const meta: Meta = {
+    title: 'Components/Primitives/TechStackChip',
+    parameters: {
+        layout: 'centered',
+        docs: {
+            description: {
+                component:
+                    "Pill chip used to label tech stack items on FeaturedProjectCard (e.g. \"React\", \"TypeScript\", \"Vite\"). Plain text inside an `<li>` — no link, no interaction."
+            }
+        }
+    },
+    decorators: [
+        (Story) => (
+            <div
+                style={{
+                    background: 'var(--almost-black)',
+                    padding: '3rem',
+                    minWidth: 360
+                }}
+            >
+                <Story />
+            </div>
+        )
+    ]
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const SingleChip: Story = {
+    render: () => (
+        <ul className="featured-project-stack">
+            <li>React</li>
+        </ul>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "One chip in isolation. Light-grey text, semi-transparent rim, fully-rounded corners."
+            }
+        }
+    }
+};
+
+export const MultipleChips: Story = {
+    render: () => (
+        <ul className="featured-project-stack">
+            <li>React</li>
+            <li>TypeScript</li>
+            <li>Vite</li>
+            <li>Storybook</li>
+            <li>Bootstrap</li>
+        </ul>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "How the chips look in production — flex-wrap row with `0.5em` gap. Mirrors the layout on FeaturedProjectCard."
+            }
+        }
+    }
+};
+
+export const LongLabels: Story = {
+    render: () => (
+        <ul
+            className="featured-project-stack"
+            style={{ maxWidth: 360 }}
+        >
+            <li>React 19</li>
+            <li>react-bootstrap 2.x</li>
+            <li>Vite + Rolldown</li>
+            <li>Storybook 10</li>
+            <li>Chromatic</li>
+            <li>Playwright</li>
+            <li>vitest</li>
+            <li>ESLint flat config</li>
+        </ul>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Wrap behavior — when there are too many chips for one row they break to the next without disrupting alignment."
+            }
+        }
+    }
+};


### PR DESCRIPTION
## Scope (expanded from initial Phase 3 descriptions pass)

Originally a docs-only first pass for `#79` Phase 3. While reviewing, surfaced and bundled in:

### IA / UX
- Top-level `Process` bucket renamed to `Design Iterations` (preview.js storySort + four story files).
- `ProjectCardHoverExploration` variants no longer hard-code `aspect-ratio: 1/1` — switched to `8/5` to match the live image.

### Missing Primitives stories
Story-only catalogue mirroring the inline JSX in live components — no source-component refactor (that's tracked in #106 for follow-up):
- Button — outline-secondary, outline-secondary disabled, hero CTA, contact submit, resume nav button.
- Input — default, filled, focused, invalid, invalid+focused, textarea.
- SliderControls — arrows, frosted dots, outlined dots, segmented progress.
- ContactFormStatus — success / error post-submit banner.
- TechStackChip — single, multiple, long-labels wrap.
- NavLink — idle, active, full-row.
- TaglineBadge — default, short, long.

### Bug fixes / live CSS scope
- `NavBar.css` `.social-icons a.social-icon` rules scoped to `nav.navbar` so they stop polluting Footer / Storybook standalone.
- `Contact.css` `:user-invalid` border bumped from salmon to a saturated red with an outer ring; the rule also keys off `[aria-invalid="true"]` for deterministic styling and as a partial step toward the a11y plumbing tracked in #107.

### Follow-ups
- `#106` — promote story-only primitives into reusable components (backlog).
- `#107` — structured ContactForm validation: inline error messages, aria-invalid/aria-describedby plumbing, focus-on-first-invalid on submit, phone format, message min length, plus extended Storybook coverage.

Closes #79 (Phase 3 portion).

## Test plan
- [ ] `npm run storybook` and walk Components/Primitives — every new story renders with the right styling.
- [ ] NavBar story still looks correct (nav-scoped CSS didn't regress live nav).
- [ ] Footer story socials are 42px circles, not stretched.
- [ ] ContactForm Invalid input shows red border + faint red bg + outer ring.
- [ ] Hero CTA story shows the button without the cosmic background bleeding in.
- [ ] Resume Nav Button hover fills white-on-dark via the `::before` pseudo.