### PR TITLE
fix(navbar): drop unscoped width: 45% on social icons

### DIFF
--- a/src/assets/styles/NavBar.css
+++ b/src/assets/styles/NavBar.css
@@ -89,11 +89,12 @@ span.navbar-text {
 }
 
 /* ==== Social Icons ==== */
-/* Scoped to nav.navbar so these overrides don't bleed into the Footer
-   or standalone Storybook usages of SocialIcons — without the scope,
-   `width: 45%` would stretch the icons globally once NavBar.css loads. */
+/* Per-image size tweaks for nav-context only (Twitter X glyph reads
+   smaller, GitHub silhouette nudged). The base `.social-icons
+   a.social-icon` sizing (42x42 circles) lives in Socials.css and is
+   shared with Footer + standalone usages — overriding the container
+   `width` here would mismatch the 42px height and paint ellipses. */
 nav.navbar .social-icons a.social-icon {
-  width: 45%;
   transition: all 0.3s ease-in-out;
 }
 


### PR DESCRIPTION
## Summary

Pre-existing live bug: NavBar's `.social-icons a.social-icon { width: 45% }` paired with Socials.css's 42px height to render the icons as wide ellipses. Visible on Vercel and local dev. Removing the width override lets Socials.css's 42×42 base apply uniformly across NavBar, Footer, and standalone usages.

Side benefit: fixes the resume button rendering too — the oversized social icons were stretching `.navbar-text`'s width, knock-on effect.

## Test plan
- [ ] Local dev nav: social icons render as 42×42 circles, not ovals.
- [ ] Resume button is left-edge-aligned with the icons (no excess parent width pushing it).
- [ ] Footer + Storybook NavBarSocials story unchanged.