### PR TITLE
perf(images): lazy + width/height + a11y on below-fold imgs (#37 phase A)

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -82,6 +82,9 @@ const Footer = () => {
                                     className="logo"
                                     src={logo}
                                     alt="Miguel Lozano Logo"
+                                    width={42}
+                                    height={42}
+                                    loading="lazy"
                                 />
                             </div>
                         </Col>

--- a/src/components/PreFooter.tsx
+++ b/src/components/PreFooter.tsx
@@ -14,12 +14,24 @@ const PreFooter = () => {
                         </h3>
                         <div className="tooling-icons">
                             <div className="tooling-icon react-icon">
-                                <img src={reactIcon} alt="react-icon" />
+                                <img
+                                    src={reactIcon}
+                                    alt="react-icon"
+                                    width={80}
+                                    height={80}
+                                    loading="lazy"
+                                />
                                 <span>React</span>
                             </div>
                             <span className="plus-sign">+</span>
                             <div className="tooling-icon bootstrap-icon">
-                                <img src={bootstrapIcon} alt="bootstrap-icon" />
+                                <img
+                                    src={bootstrapIcon}
+                                    alt="bootstrap-icon"
+                                    width={80}
+                                    height={80}
+                                    loading="lazy"
+                                />
                                 <span>Bootstrap</span>
                             </div>
                         </div>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -142,8 +142,10 @@ const Projects = ({ initialInView = false }: ProjectsProps = {}) => {
         <section id="projects" className="projects">
             <img
                 src={colorPop}
-                alt="decorative background"
+                alt=""
+                aria-hidden="true"
                 className="background-image-right"
+                loading="lazy"
             />
             <Container>
                 <Row>

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -12,8 +12,10 @@ const Skills = () => {
         <section id="skills" className="skills">
             <img
                 src={colorPop}
-                alt="decorative background"
+                alt=""
+                aria-hidden="true"
                 className="background-image-left"
+                loading="lazy"
             />
             <Container>
                 <Row>

--- a/src/components/SkillsCarousel.tsx
+++ b/src/components/SkillsCarousel.tsx
@@ -197,6 +197,7 @@ const SkillsCarousel = () => {
                                 className={`custom-skill-icon ${
                                     isCrossFade ? "icon-inactive" : ""
                                 }`}
+                                loading="lazy"
                             />
                         ) : (
                             skill.class && (
@@ -215,6 +216,7 @@ const SkillsCarousel = () => {
                                 className={`custom-skill-icon ${
                                     isCrossFade ? "icon-active" : ""
                                 }`}
+                                loading="lazy"
                             />
                         )}
                         <h5>{skill.name}</h5>

--- a/src/components/SocialIcons.tsx
+++ b/src/components/SocialIcons.tsx
@@ -27,7 +27,7 @@ const SocialIcons = ({ config, onHover }: SocialIconsProps) => {
                         onMouseEnter={() => onHover?.(social.label)}
                         onMouseLeave={() => onHover?.(null)}
                     >
-                        <img src={social.icon} alt={social.label} />
+                        <img src={social.icon} alt={social.label} loading="lazy" />
                     </a>
                 );
             })}


### PR DESCRIPTION
## Summary

Phase A of #37. Cheap-and-safe wins before the bigger WebP / image-set work.

- `loading=\"lazy\"` added to PreFooter tooling icons, Footer logo, SocialIcons, SkillsCarousel skill icons (inactive + active), and the colorPop decorative bg in Projects + Skills.
- `width`/`height` set where dimensions are stable (PreFooter 80×80, Footer logo 42×42) — prevents CLS on those slots.
- The two `colorPop` decorative backgrounds flipped to `alt=\"\"` + `aria-hidden=\"true\"` so screen readers skip them. Consistent with their visual-only role.

Above-fold images (Hero floating bitmoji, NavBar logo, FeaturedImageSlider lightbox `<img>` which only mounts on user click) intentionally untouched.

## Out of scope (follow-up phases of #37)

- **B**: convert project PNGs to WebP/AVIF with PNG fallback via `<picture>`.
- **C**: move decorative backgrounds to CSS `image-set()` for AVIF/WebP.

## Test plan
- [ ] `npm test` green.
- [ ] Local dev — Skills carousel icons still render, no FOUC.
- [ ] Footer logo visible at 42×42.
- [ ] PreFooter React + Bootstrap icons render at 80×80.
- [ ] No console warnings around image attributes.