### PR TITLE
fix(storybook): force VITE_MOCK_FORM empty so per-story axios mocks aren't bypassed

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -12,6 +12,18 @@ const config = {
     "@storybook/addon-a11y",
     "@storybook/addon-docs"
   ],
-  "framework": "@storybook/react-vite"
+  "framework": "@storybook/react-vite",
+  /* Force VITE_MOCK_FORM to empty inside Storybook builds. The app's
+     ContactForm checks this env var BEFORE reaching axios.post, so any
+     non-empty value (e.g. our local "throw" used for live-site error-UI
+     testing) bypasses the per-story axios mocks and forces every state
+     story into the error path. */
+  viteFinal: async (config) => {
+    config.define = {
+      ...config.define,
+      'import.meta.env.VITE_MOCK_FORM': JSON.stringify('')
+    };
+    return config;
+  }
 };
 export default config;


### PR DESCRIPTION
## Summary

ContactForm reads `VITE_MOCK_FORM` before reaching `axios.post`. When the env is set to a non-empty value (e.g. the local "throw" mode used to exercise the live-site error UI), Storybook's per-story axios mocks get skipped and every ContactForm state story (Submitting, Success, Error) collapses into the error path.

This adds a `viteFinal` hook in `.storybook/main.js` that defines `import.meta.env.VITE_MOCK_FORM` as `''` for Storybook builds only. The dev/prod app behavior is unchanged.

## Why now

Surfaced while reviewing existing ContactForm + Input stories in preparation for #107 (validation refactor). Without this fix, the validation-state stories that #107's acceptance calls for can't render correctly.

## Test plan

- [ ] `npm run storybook` → ContactForm `Submitting`, `Success`, `Error` stories render their intended state (not all forced into Error)
- [ ] App `npm run dev` still respects local `VITE_MOCK_FORM` env (Storybook override does not leak)