### PR TITLE
feat(contact-form): inline validation, aria plumbing, error animation fix (#107)

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -12,6 +12,18 @@ const config = {
     "@storybook/addon-a11y",
     "@storybook/addon-docs"
   ],
-  "framework": "@storybook/react-vite"
+  "framework": "@storybook/react-vite",
+  /* Force VITE_MOCK_FORM to empty inside Storybook builds. The app's
+     ContactForm checks this env var BEFORE reaching axios.post, so any
+     non-empty value (e.g. our local "throw" used for live-site error-UI
+     testing) bypasses the per-story axios mocks and forces every state
+     story into the error path. */
+  viteFinal: async (config) => {
+    config.define = {
+      ...config.define,
+      'import.meta.env.VITE_MOCK_FORM': JSON.stringify('')
+    };
+    return config;
+  }
 };
 export default config;

--- a/src/assets/styles/Contact.css
+++ b/src/assets/styles/Contact.css
@@ -129,6 +129,15 @@
     opacity: 0.8;
 }
 
+.contact form .field-error {
+    display: block;
+    color: #fca5a5;
+    font-size: 0.875em;
+    line-height: 1.3;
+    margin: -4px 0 8px 4px;
+    text-align: left;
+}
+
 .contact form .submit-container {
     display: flex;
     flex-direction: column;

--- a/src/assets/styles/Contact.css
+++ b/src/assets/styles/Contact.css
@@ -332,18 +332,3 @@
 
 }
 
-@media screen and (min-width:992px) {
-    .contact form .submit-container {
-        flex-direction: row;
-        align-items: center;
-    }
-
-    .contact form button {
-        width: auto;
-    }
-
-    .contact form .form-status-message {
-        margin: 0 0 0 2em;
-        flex: 1;
-    }
-}

--- a/src/assets/styles/Contact.css
+++ b/src/assets/styles/Contact.css
@@ -135,7 +135,7 @@
     background: transparent;
     border: 1px solid transparent;
     border-radius: 0.4em;
-    padding: 13px 26px;
+    padding: 13px 13px;
     animation: status-box-fade 0.35s ease-out 0.7s forwards;
 }
 

--- a/src/assets/styles/Contact.css
+++ b/src/assets/styles/Contact.css
@@ -240,7 +240,7 @@
     font-weight: 700;
     padding: 14px 48px;
     min-width: 11em;
-    width: auto;
+    width: 100%;
     position: relative;
     z-index: 2;
     transition: opacity 0.3s ease-in-out, background-color 0.3s ease-in-out, color 0.3s ease-in-out;
@@ -332,3 +332,8 @@
 
 }
 
+@media screen and (min-width:992px) {
+    .contact form button {
+        width: auto;
+    }
+}

--- a/src/assets/styles/Contact.css
+++ b/src/assets/styles/Contact.css
@@ -240,7 +240,7 @@
     font-weight: 700;
     padding: 14px 48px;
     min-width: 11em;
-    width: 100%;
+    width: auto;
     position: relative;
     z-index: 2;
     transition: opacity 0.3s ease-in-out, background-color 0.3s ease-in-out, color 0.3s ease-in-out;

--- a/src/assets/styles/Contact.css
+++ b/src/assets/styles/Contact.css
@@ -106,6 +106,23 @@
     border-color: rgba(220, 38, 38, 1);
 }
 
+/* When the form-level error banner is up (API/server failure), suppress
+   per-field :user-invalid styling — the issue isn't with the field
+   contents, so the red highlighting is misleading. */
+.contact form.has-form-error input:user-invalid,
+.contact form.has-form-error textarea:user-invalid {
+    border-color: rgba(255, 255, 255, 0.5);
+    background: rgba(255, 255, 255, 0.1);
+    box-shadow: none;
+}
+
+.contact form.has-form-error input:user-invalid:focus,
+.contact form.has-form-error textarea:user-invalid:focus {
+    background: rgba(255, 255, 255, 1);
+    color: var(--dark-grey);
+    border-color: rgba(255, 255, 255, 0.5);
+}
+
 .contact form input:focus::placeholder, .contact form textarea:focus::placeholder {
     color: var(--dark-grey);
     opacity: 0.8;

--- a/src/assets/styles/Contact.css
+++ b/src/assets/styles/Contact.css
@@ -106,18 +106,19 @@
     border-color: rgba(220, 38, 38, 1);
 }
 
-/* When the form-level error banner is up (API/server failure), suppress
-   per-field :user-invalid styling — the issue isn't with the field
-   contents, so the red highlighting is misleading. */
-.contact form.has-form-error input:user-invalid,
-.contact form.has-form-error textarea:user-invalid {
+/* Once the form has a result (success cleared fields → required + empty,
+   or API error → server-side issue, not field contents), suppress the
+   per-field :user-invalid red highlight. The form-level message carries
+   the feedback. */
+.contact form.is-resolved input:user-invalid,
+.contact form.is-resolved textarea:user-invalid {
     border-color: rgba(255, 255, 255, 0.5);
     background: rgba(255, 255, 255, 0.1);
     box-shadow: none;
 }
 
-.contact form.has-form-error input:user-invalid:focus,
-.contact form.has-form-error textarea:user-invalid:focus {
+.contact form.is-resolved input:user-invalid:focus,
+.contact form.is-resolved textarea:user-invalid:focus {
     background: rgba(255, 255, 255, 1);
     color: var(--dark-grey);
     border-color: rgba(255, 255, 255, 0.5);

--- a/src/assets/styles/Contact.css
+++ b/src/assets/styles/Contact.css
@@ -240,7 +240,7 @@
     font-weight: 700;
     padding: 14px 48px;
     min-width: 11em;
-    width: auto;
+    width: 100%;
     position: relative;
     z-index: 2;
     transition: opacity 0.3s ease-in-out, background-color 0.3s ease-in-out, color 0.3s ease-in-out;
@@ -332,3 +332,18 @@
 
 }
 
+@media screen and (min-width:992px) {
+    .contact form .submit-container {
+        flex-direction: row;
+        align-items: center;
+    }
+
+    .contact form button {
+        width: auto;
+    }
+
+    .contact form .form-status-message {
+        margin: 0 0 0 2em;
+        flex: 1;
+    }
+}

--- a/src/assets/styles/Contact.css
+++ b/src/assets/styles/Contact.css
@@ -138,6 +138,13 @@
     text-align: left;
 }
 
+/* Textareas have margin-bottom: 32px (vs 8px on inputs) for breathing
+   room before the submit row. When an error follows, pull it up so the
+   gap matches the tighter input + error spacing. */
+.contact form textarea + .field-error {
+    margin-top: -28px;
+}
+
 .contact form .submit-container {
     display: flex;
     flex-direction: column;

--- a/src/assets/styles/Contact.css
+++ b/src/assets/styles/Contact.css
@@ -88,8 +88,6 @@
     color: #fff;
 }
 
-.contact form input:user-invalid,
-.contact form textarea:user-invalid,
 .contact form input[aria-invalid="true"],
 .contact form textarea[aria-invalid="true"] {
     border-color: rgba(239, 68, 68, 0.95);
@@ -97,31 +95,11 @@
     box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.45);
 }
 
-.contact form input:user-invalid:focus,
-.contact form textarea:user-invalid:focus,
 .contact form input[aria-invalid="true"]:focus,
 .contact form textarea[aria-invalid="true"]:focus {
     background: rgba(255, 255, 255, 1);
     color: var(--dark-grey);
     border-color: rgba(220, 38, 38, 1);
-}
-
-/* Once the form has a result (success cleared fields → required + empty,
-   or API error → server-side issue, not field contents), suppress the
-   per-field :user-invalid red highlight. The form-level message carries
-   the feedback. */
-.contact form.is-resolved input:user-invalid,
-.contact form.is-resolved textarea:user-invalid {
-    border-color: rgba(255, 255, 255, 0.5);
-    background: rgba(255, 255, 255, 0.1);
-    box-shadow: none;
-}
-
-.contact form.is-resolved input:user-invalid:focus,
-.contact form.is-resolved textarea:user-invalid:focus {
-    background: rgba(255, 255, 255, 1);
-    color: var(--dark-grey);
-    border-color: rgba(255, 255, 255, 0.5);
 }
 
 .contact form input:focus::placeholder, .contact form textarea:focus::placeholder {

--- a/src/assets/styles/Contact.css
+++ b/src/assets/styles/Contact.css
@@ -240,7 +240,7 @@
     font-weight: 700;
     padding: 14px 48px;
     min-width: 11em;
-    width: 100%;
+    width: auto;
     position: relative;
     z-index: 2;
     transition: opacity 0.3s ease-in-out, background-color 0.3s ease-in-out, color 0.3s ease-in-out;
@@ -332,8 +332,3 @@
 
 }
 
-@media screen and (min-width:992px) {
-    .contact form button {
-        width: auto;
-    }
-}

--- a/src/components/ContactForm.stories.tsx
+++ b/src/components/ContactForm.stories.tsx
@@ -170,8 +170,8 @@ export const Failed: Story = {
 };
 
 // Client-side validation error. Every required field is filled except
-// Last Name; clicking Send triggers the browser's HTML5 validation,
-// blocks submit, and flips :user-invalid on the empty Last Name field.
+// Last Name; clicking Send triggers React validation, blocks submit, and
+// surfaces an inline "Last name is required." message under the field.
 export const Error: Story = {
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
@@ -190,6 +190,57 @@ export const Error: Story = {
         await userEvent.type(
             canvas.getByPlaceholderText(/Message/i),
             "Loved your portfolio — would like to chat about a senior frontend role."
+        );
+        await userEvent.click(canvas.getByRole('button', { name: /send/i }));
+    }
+};
+
+// Malformed email — all required fields filled, but the email value is
+// missing the @-and-domain. Clicking Send surfaces "Enter a valid email
+// address." inline under the email input.
+export const MalformedEmail: Story = {
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await userEvent.type(
+            canvas.getByPlaceholderText(/First Name/i),
+            'Alex'
+        );
+        await userEvent.type(
+            canvas.getByPlaceholderText(/Last Name/i),
+            'Smith'
+        );
+        await userEvent.type(
+            canvas.getByPlaceholderText(/Email Address/i),
+            'not-an-email'
+        );
+        await userEvent.type(
+            canvas.getByPlaceholderText(/Message/i),
+            "Loved your portfolio — would like to chat about a senior frontend role."
+        );
+        await userEvent.click(canvas.getByRole('button', { name: /send/i }));
+    }
+};
+
+// Message under the 20-character minimum. Clicking Send surfaces
+// "Please write at least 20 characters." inline under the textarea.
+export const MessageTooShort: Story = {
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await userEvent.type(
+            canvas.getByPlaceholderText(/First Name/i),
+            'Alex'
+        );
+        await userEvent.type(
+            canvas.getByPlaceholderText(/Last Name/i),
+            'Smith'
+        );
+        await userEvent.type(
+            canvas.getByPlaceholderText(/Email Address/i),
+            'alex.smith@example.com'
+        );
+        await userEvent.type(
+            canvas.getByPlaceholderText(/Message/i),
+            'Hi.'
         );
         await userEvent.click(canvas.getByRole('button', { name: /send/i }));
     }

--- a/src/components/ContactForm.stories.tsx
+++ b/src/components/ContactForm.stories.tsx
@@ -221,6 +221,25 @@ export const MalformedEmail: Story = {
     }
 };
 
+// Two required fields empty (First Name and Email). Asserts that on
+// submit, focus moves to the *first* invalid field in document order
+// (First Name) — not whichever field the user last interacted with.
+export const SubmittedInvalid: Story = {
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await userEvent.type(
+            canvas.getByPlaceholderText(/Last Name/i),
+            'Smith'
+        );
+        await userEvent.type(
+            canvas.getByPlaceholderText(/Message/i),
+            "Loved your portfolio — would like to chat about a senior frontend role."
+        );
+        await userEvent.click(canvas.getByRole('button', { name: /send/i }));
+        await expect(canvas.getByPlaceholderText(/First Name/i)).toHaveFocus();
+    }
+};
+
 // Message under the 20-character minimum. Clicking Send surfaces
 // "Please write at least 20 characters." inline under the textarea.
 export const MessageTooShort: Story = {

--- a/src/components/ContactForm.stories.tsx
+++ b/src/components/ContactForm.stories.tsx
@@ -40,15 +40,15 @@ export const Empty: Story = {};
 const fillFields = async (canvas: ReturnType<typeof within>) => {
     await userEvent.type(
         canvas.getByPlaceholderText(/First Name/i),
-        'Miguel'
+        'Alex'
     );
     await userEvent.type(
         canvas.getByPlaceholderText(/Last Name/i),
-        'Lozano'
+        'Smith'
     );
     await userEvent.type(
         canvas.getByPlaceholderText(/Email Address/i),
-        'miguel@example.com'
+        'alex.smith@example.com'
     );
     await userEvent.type(
         canvas.getByPlaceholderText(/Phone Number/i),
@@ -66,7 +66,7 @@ export const Filled: Story = {
         const canvas = within(canvasElement);
         await fillFields(canvas);
         await expect(canvas.getByPlaceholderText(/First Name/i)).toHaveValue(
-            'Miguel'
+            'Alex'
         );
     }
 };
@@ -166,5 +166,31 @@ export const Failed: Story = {
         await expect(
             await canvas.findByText(/Oops! Request Failed/i)
         ).toBeInTheDocument();
+    }
+};
+
+// Client-side validation error. Every required field is filled except
+// Last Name; clicking Send triggers the browser's HTML5 validation,
+// blocks submit, and flips :user-invalid on the empty Last Name field.
+export const Error: Story = {
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await userEvent.type(
+            canvas.getByPlaceholderText(/First Name/i),
+            'Alex'
+        );
+        await userEvent.type(
+            canvas.getByPlaceholderText(/Email Address/i),
+            'alex.smith@example.com'
+        );
+        await userEvent.type(
+            canvas.getByPlaceholderText(/Phone Number/i),
+            '5555550100'
+        );
+        await userEvent.type(
+            canvas.getByPlaceholderText(/Message/i),
+            "Loved your portfolio — would like to chat about a senior frontend role."
+        );
+        await userEvent.click(canvas.getByRole('button', { name: /send/i }));
     }
 };

--- a/src/components/ContactForm.stories.tsx
+++ b/src/components/ContactForm.stories.tsx
@@ -155,7 +155,7 @@ export const Success: Story = {
 
 // Failure path. Mock rejects with a network error so the form surfaces
 // the "Oops! Request Failed" message.
-export const Error: Story = {
+export const Failed: Story = {
     render: () => (
         <MockedContactForm response={{ kind: 'network-error' }} delayMs={50} />
     ),

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -198,7 +198,6 @@ const ContactForm = () => {
             ref={formRef}
             onSubmit={onFormSubmit}
             noValidate
-            className={formStatus.success !== null ? "is-resolved" : ""}
         >
             <input
                 type="text"

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { ChangeEvent, FormEvent } from "react";
 import axios from "axios";
 import { Col, Row } from "react-bootstrap";
@@ -11,6 +11,43 @@ type FormStatus = {
 };
 
 type SubmitResponse = { status: number; data: { success: boolean; message: string } };
+
+const initialValues = {
+    firstName: "",
+    lastName: "",
+    email: "",
+    phone: "",
+    message: "",
+    botcheck: ""
+};
+
+type FormValues = typeof initialValues;
+type FieldName = "firstName" | "lastName" | "email" | "message";
+type FieldErrors = Partial<Record<FieldName, string>>;
+
+const MESSAGE_MIN_LENGTH = 20;
+const FIELD_ORDER: FieldName[] = ["firstName", "lastName", "email", "message"];
+
+const validate = (values: FormValues): FieldErrors => {
+    const errs: FieldErrors = {};
+    if (!values.firstName.trim()) {
+        errs.firstName = "First name is required.";
+    }
+    if (!values.lastName.trim()) {
+        errs.lastName = "Last name is required.";
+    }
+    if (!values.email.trim()) {
+        errs.email = "Email is required.";
+    } else if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(values.email.trim())) {
+        errs.email = "Enter a valid email address.";
+    }
+    if (!values.message.trim()) {
+        errs.message = "Message is required.";
+    } else if (values.message.trim().length < MESSAGE_MIN_LENGTH) {
+        errs.message = `Please write at least ${MESSAGE_MIN_LENGTH} characters.`;
+    }
+    return errs;
+};
 
 const submitForm = async (
     payload: Record<string, string>
@@ -31,25 +68,24 @@ const submitForm = async (
 };
 
 const ContactForm = () => {
-    const initialValues = {
-        firstName: "",
-        lastName: "",
-        email: "",
-        phone: "",
-        message: "",
-        botcheck: ""
-    };
-    const [formValues, setFormValues] = useState(initialValues);
+    const [formValues, setFormValues] = useState<FormValues>(initialValues);
     const [buttonText, setButtonText] = useState("Send");
     const [loading, setLoading] = useState(false);
+    const [submitAttempted, setSubmitAttempted] = useState(false);
     const [formStatus, setFormStatus] = useState<FormStatus>({
         status: null,
         success: null,
         error: null,
         message: ""
     });
+    const formRef = useRef<HTMLFormElement>(null);
 
     const isSent = formStatus.success === true;
+
+    // Errors render only after the user attempts submit. Derived from
+    // formValues each render, so messages clear themselves as fields are
+    // fixed without needing a separate effect/state.
+    const errors: FieldErrors = submitAttempted ? validate(formValues) : {};
 
     const onFormChange = () => {
         return (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -65,6 +101,19 @@ const ContactForm = () => {
     const onFormSubmit = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         if (loading || isSent) return;
+
+        const errs = validate(formValues);
+        setSubmitAttempted(true);
+        if (Object.keys(errs).length > 0) {
+            const firstInvalid = FIELD_ORDER.find((f) => errs[f]);
+            if (firstInvalid) {
+                formRef.current
+                    ?.querySelector<HTMLElement>(`[name="${firstInvalid}"]`)
+                    ?.focus();
+            }
+            return;
+        }
+
         setButtonText("Sending...");
         setLoading(true);
 
@@ -84,6 +133,7 @@ const ContactForm = () => {
                         message: "Thanks for reaching out, I'll be in touch!"
                     });
                     setFormValues(initialValues);
+                    setSubmitAttempted(false);
                     setButtonText("Sent ✓");
                 } else {
                     setFormStatus({
@@ -123,9 +173,31 @@ const ContactForm = () => {
             ? "danger"
             : "";
 
+    const fieldError = (name: FieldName) => {
+        const err = errors[name];
+        if (!err) return null;
+        return (
+            <span
+                id={`${name}-error`}
+                role="alert"
+                aria-live="polite"
+                className="field-error"
+            >
+                {err}
+            </span>
+        );
+    };
+
+    const ariaProps = (name: FieldName) => ({
+        "aria-invalid": !!errors[name],
+        "aria-describedby": errors[name] ? `${name}-error` : undefined
+    });
+
     return (
         <form
+            ref={formRef}
             onSubmit={onFormSubmit}
+            noValidate
             className={formStatus.success !== null ? "is-resolved" : ""}
         >
             <input
@@ -149,7 +221,9 @@ const ContactForm = () => {
                         autoComplete="given-name"
                         onChange={onFormChange()}
                         required
+                        {...ariaProps("firstName")}
                     />
+                    {fieldError("firstName")}
                 </Col>
                 <Col className="px-1" sm={6}>
                     <input
@@ -161,7 +235,9 @@ const ContactForm = () => {
                         autoComplete="family-name"
                         onChange={onFormChange()}
                         required
+                        {...ariaProps("lastName")}
                     />
+                    {fieldError("lastName")}
                 </Col>
             </Row>
             <Row>
@@ -175,7 +251,9 @@ const ContactForm = () => {
                         autoComplete="email"
                         onChange={onFormChange()}
                         required
+                        {...ariaProps("email")}
                     />
+                    {fieldError("email")}
                 </Col>
                 <Col className="px-1" sm={6}>
                     <input
@@ -197,9 +275,12 @@ const ContactForm = () => {
                         placeholder="Message *"
                         aria-label="Message (required)"
                         autoComplete="off"
+                        minLength={MESSAGE_MIN_LENGTH}
                         onChange={onFormChange()}
                         required
+                        {...ariaProps("message")}
                     />
+                    {fieldError("message")}
                 </Col>
                 <div className={containerClasses}>
                     <button

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -98,7 +98,8 @@ const ContactForm = () => {
             })
             .catch((error: Error) => {
                 setFormStatus({
-                    ...formStatus,
+                    success: false,
+                    status: null,
                     error: error.message,
                     message: "Oops! Request Failed. Please try again soon"
                 });

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -126,7 +126,7 @@ const ContactForm = () => {
     return (
         <form
             onSubmit={onFormSubmit}
-            className={formStatus.success === false ? "has-form-error" : ""}
+            className={formStatus.success !== null ? "is-resolved" : ""}
         >
             <input
                 type="text"

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -124,7 +124,10 @@ const ContactForm = () => {
             : "";
 
     return (
-        <form onSubmit={onFormSubmit}>
+        <form
+            onSubmit={onFormSubmit}
+            className={formStatus.success === false ? "has-form-error" : ""}
+        >
             <input
                 type="text"
                 name="botcheck"

--- a/src/components/InputPrimitive.stories.tsx
+++ b/src/components/InputPrimitive.stories.tsx
@@ -77,7 +77,7 @@ export const Filled: Story = {
                 <input
                     type="text"
                     name="firstName"
-                    defaultValue="Miguel"
+                    defaultValue="Alex"
                     placeholder="First Name *"
                     aria-label="First Name (required)"
                     required
@@ -87,7 +87,7 @@ export const Filled: Story = {
                 <input
                     type="email"
                     name="email"
-                    defaultValue="miguel@example.com"
+                    defaultValue="alex.smith@example.com"
                     placeholder="Email Address *"
                     aria-label="Email Address (required)"
                     required


### PR DESCRIPTION
## Summary

Implements the bulk of #107 — structured ContactForm validation with inline errors, aria plumbing, and a real fix for the error-state animation that wasn't firing.

### Validation
- React-owned validation via `validate(formValues)` — required fields, email shape, message `>=20` chars. Custom copy per failure mode.
- `noValidate` on the form so the browser doesn't show native popups; React renders inline messages instead.
- On submit: if errors, focus the first invalid field in document order and abort. After a failed submit, errors are derived from `formValues` each render so they clear themselves as the user fixes fields (no `useEffect` cascade).

### A11y plumbing
- Each required input gets `aria-invalid` + `aria-describedby` pointing at its inline `<span role="alert" aria-live="polite">`.
- Inline message styled small + red (`#fca5a5`) with tightened spacing under textarea so it matches input spacing.

### Bug fixes folded in
- **Error animation never fired** — `.catch` was spreading prior `formStatus` (success: null), so `.danger` class never landed and `error-icon` never rendered. Now sets `success: false` explicitly.
- **Status message wrapped to 2 lines** — `.form-status-message` padding tightened from `13px 26px` to `13px 13px`.
- **Storybook ContactForm stories all forced into Error path** — `viteFinal` block defines `import.meta.env.VITE_MOCK_FORM` as `''` for Storybook builds so per-story axios mocks aren't bypassed. (Cherry-picked from #114; collapses on rebase if #114 lands first.)

### Story coverage (Components/Composites/ContactForm)
- `Empty`, `Filled`, `Submitting`, `Success`, `Failed` (renamed from `Error`)
- `Error` — Last Name empty (required field)
- `MalformedEmail` — bad email format
- `MessageTooShort` — under 20 chars
- `SubmittedInvalid` — asserts focus moves to first invalid field

Example user across all stories changed from `Miguel Lozano` to `Alex Smith` so the public-facing Storybook doesn't show the author's own data.

### Cleanup
- Dropped `:user-invalid` CSS selectors (dead with `noValidate` — `aria-invalid="true"` drives the red treatment).
- Dropped `is-resolved` class (was a workaround for `:user-invalid` firing on cleared post-submit fields; obsolete now).

## Out of scope (follow-ups for #107 if wanted)
- Honeypot validation feedback (botcheck currently trips silently)
- WCAG contrast verification on the invalid-border red
- Phone format validation (intentionally left permissive per discussion)

## Test plan

- [ ] `Components/Composites/ContactForm`:
  - [ ] `Empty` / `Filled` render normally
  - [ ] `Submitting` pins button to "Sending..."
  - [ ] `Success` shows envelope icon + "Thanks for reaching out, I'll be in touch!" message animation
  - [ ] `Failed` shows error icon + "Oops! Request Failed..." message animation
  - [ ] `Error` shows inline "Last name is required."
  - [ ] `MalformedEmail` shows inline "Enter a valid email address."
  - [ ] `MessageTooShort` shows inline "Please write at least 20 characters."
  - [ ] `SubmittedInvalid` — focus moves to First Name field (story asserts via `toHaveFocus()`)
- [ ] `npm run dev` — submit a fully filled valid form and verify success path against a real Web3Forms key (or mock)
- [ ] Note: closes #107 won't auto-fire on dev merge — close manually after review