### PR TITLE
perf(animations): cut high-frequency rerenders on hover/auto-advance/resize (#78)

### DIFF
--- a/src/components/FeaturedImageSlider.tsx
+++ b/src/components/FeaturedImageSlider.tsx
@@ -87,6 +87,14 @@ const FeaturedImageSlider = ({
 
     useEffect(() => {
         if (effectivelyPaused || images.length <= 1) return;
+        // Only the segmented-progress indicator actually reads `progress`.
+        // For other indicators, gate the autoplay loop on a single setTimeout
+        // instead of a 60Hz rAF + setState — saves ~60 component rerenders
+        // per second of autoplay.
+        if (indicator !== 'segmented-progress') {
+            const t = window.setTimeout(next, intervalMs);
+            return () => window.clearTimeout(t);
+        }
         let raf = 0;
         const start = performance.now() - progress * intervalMs;
         const tick = (now: number) => {
@@ -101,7 +109,7 @@ const FeaturedImageSlider = ({
         raf = requestAnimationFrame(tick);
         return () => cancelAnimationFrame(raf);
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [effectivelyPaused, intervalMs, images.length, index]);
+    }, [effectivelyPaused, intervalMs, images.length, index, indicator]);
 
     // Lightbox keyboard nav: Esc closes, arrows navigate.
     useEffect(() => {

--- a/src/components/HoverZoomPan.tsx
+++ b/src/components/HoverZoomPan.tsx
@@ -1,4 +1,4 @@
-import { useState, type MouseEvent } from 'react';
+import { useRef, useState, type MouseEvent } from 'react';
 
 type Props = {
     src: string;
@@ -18,21 +18,31 @@ const HoverZoomPan = ({
     zoomScale = 1.63,
     transitionMs = 963
 }: Props) => {
-    const [origin, setOrigin] = useState({ x: 50, y: 50 });
+    // transformOrigin is purely visual state — write it to the DOM directly via
+    // ref instead of going through React state. setState on every mousemove
+    // would force a full component rerender 60+ times per second.
+    const imgRef = useRef<HTMLImageElement>(null);
     const [hovered, setHovered] = useState(false);
 
     const handleMouseMove = (e: MouseEvent<HTMLDivElement>) => {
+        if (!imgRef.current) return;
         const rect = e.currentTarget.getBoundingClientRect();
         const x = ((e.clientX - rect.left) / rect.width) * 100;
         const y = ((e.clientY - rect.top) / rect.height) * 100;
-        setOrigin({ x, y });
+        imgRef.current.style.transformOrigin = `${x}% ${y}%`;
+    };
+
+    const handleMouseLeave = () => {
+        setHovered(false);
+        if (imgRef.current) {
+            imgRef.current.style.transformOrigin = '50% 50%';
+        }
     };
 
     const imgStyle: React.CSSProperties = {
         width: '100%',
         height: '100%',
         objectFit: 'cover',
-        transformOrigin: `${origin.x}% ${origin.y}%`,
         transform: hovered ? `scale(${zoomScale})` : 'scale(1)',
         transition: `transform ${transitionMs}ms cubic-bezier(0.4, 0, 0.2, 1)`
     };
@@ -46,12 +56,12 @@ const HoverZoomPan = ({
                 cursor: hovered ? 'zoom-in' : 'default'
             }}
             onMouseEnter={() => setHovered(true)}
-            onMouseLeave={() => setHovered(false)}
+            onMouseLeave={handleMouseLeave}
             onMouseMove={handleMouseMove}
         >
             <picture>
                 {srcWebp && <source srcSet={srcWebp} type="image/webp" />}
-                <img src={src} alt={alt} loading="lazy" style={imgStyle} />
+                <img ref={imgRef} src={src} alt={alt} loading="lazy" style={imgStyle} />
             </picture>
         </div>
     );

--- a/src/components/MomentumTabs.tsx
+++ b/src/components/MomentumTabs.tsx
@@ -53,11 +53,23 @@ const MomentumTabs = <T extends string>({
     // Mirror of `isResizing` accessible synchronously inside the resize handler
     // so we only fire setState once per resize session, not on every tick.
     const isResizingRef = useRef(false);
+    // Mirror of `active` for the resize handler — lets us attach the listener
+    // once on mount instead of re-attaching it every time `active` changes.
+    const activeRef = useRef(active);
+    useEffect(() => {
+        activeRef.current = active;
+    }, [active]);
 
     const clearTimers = () => {
         transitionTimers.current.forEach((id) => window.clearTimeout(id));
         transitionTimers.current = [];
     };
+
+    // Drain pending click-animation timers on unmount so they can't fire
+    // setState on an unmounted component.
+    useEffect(() => {
+        return () => clearTimers();
+    }, []);
 
     // Gated on `enabled` so we only measure once the parent signals the
     // section is in view. Important when the parent has `content-visibility: auto`
@@ -95,6 +107,8 @@ const MomentumTabs = <T extends string>({
     // Keep the indicator pinned to the active tab when the viewport resizes.
     // Fade out on first resize tick (gated by ref so setState fires once per
     // session, not per tick), re-measure + fade back in once resize idles.
+    // Listener is attached once on mount; the handler reads the latest
+    // `active` via activeRef to avoid re-attaching on every tab change.
     useEffect(() => {
         let settleTimer: number | undefined;
         const handleResize = () => {
@@ -105,7 +119,7 @@ const MomentumTabs = <T extends string>({
             if (settleTimer !== undefined) window.clearTimeout(settleTimer);
             settleTimer = window.setTimeout(() => {
                 if (!isAnimatingRef.current) {
-                    const el = buttonRefs.current[active];
+                    const el = buttonRefs.current[activeRef.current];
                     if (el) {
                         setIndicator({
                             left: el.offsetLeft,
@@ -130,7 +144,7 @@ const MomentumTabs = <T extends string>({
             window.removeEventListener('resize', handleResize);
             if (settleTimer !== undefined) window.clearTimeout(settleTimer);
         };
-    }, [active]);
+    }, []);
 
     const handleClick = (next: T) => {
         if (next === active) return;


### PR DESCRIPTION
## Summary

Three targeted fixes from #78's audit playbook. Each addresses an identified hot path; deeper memoization refactors deferred until profiler data justifies them.

### HoverZoomPan
`setState` fired on every `mousemove` to track `transformOrigin` — full component rerender 60+ times per second on hover. Switched to **ref-based DOM write**: `imgRef.current.style.transformOrigin = ...`. React state stays only for `hovered` (drives cursor + scale). Bonus: reset to `50% 50%` on mouseleave so the next hover starts centered.

### FeaturedImageSlider
The rAF progress tick fired `setProgress` every animation frame, forcing a full slider rerender at 60Hz during autoplay — even for indicators that don't read `progress` (`frosted-dots`, `counter`, `outlined-dots`). **Gated** the rAF loop to `indicator === 'segmented-progress'` only; other indicators get a single `setTimeout` for the advance.

### MomentumTabs
- Resize listener was attached on `[active]` so it **re-attached every tab change**. Mirror `active` into a ref synced via effect; listener attaches once on mount, reads latest via ref.
- Added unmount cleanup draining pending click-animation timers — prevents `setState` on an unmounted component when the user navigates away mid-tab-transition.

## Out of scope (deferred)
- `Projects.tsx` tab fade/swap state machine — read fine, no obvious churn.
- `ProjectList` / `ProjectCard` / Skills carousel — no rerender hot paths surfaced without profiler data.
- `React.memo` on `FeaturedProjectCard` etc. — would require parent-side `useMemo` on inline arrays/objects, deeper risk; defer until profiler data justifies it.

## Test plan

- [ ] `npm run dev` — open Projects section
- [ ] Featured tab → hover Branch Beacon image: zoom + pan still works smoothly, no React rerender on mousemove (verify in DevTools Profiler)
- [ ] Featured tab → BCBS slider auto-advances at 3.69s without progress bar; no 60Hz tick (Profiler should show one render per slide change, not per frame)
- [ ] Personal tab → Pattern Archive slider with `arrows + keyboard + swipe` controls still works
- [ ] Resize the window while on Projects → indicator fades during resize, snaps to active tab on settle, fades back in
- [ ] Switch tabs rapidly + navigate away mid-transition → no console warnings about setState on unmounted component
- [ ] Build green: `npm run build` ✓
- [ ] Type check green: `npx tsc --noEmit` ✓
- [ ] Note: closes #78 won't auto-fire on dev merge — close manually after review