### PR TITLE
fix(a11y): lift Lighthouse a11y from 94 to 100 (#121)

### DIFF
--- a/src/assets/styles/Footer.css
+++ b/src/assets/styles/Footer.css
@@ -126,7 +126,7 @@
 }
 
 .footer .footer-right {
-    color: #757575;
+    color: #a0a0a0;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/assets/styles/Skills.css
+++ b/src/assets/styles/Skills.css
@@ -67,6 +67,15 @@
     opacity: 1;
 }
 
+/* Skill name was an <h5> previously — switched to <span> to fix Lighthouse
+   heading-order audit (page hierarchy went h2 Skills → h5 skip). Restore
+   the original visual size + weight so the carousel reads identically. */
+.skills-slider .item .skill-name {
+    display: block;
+    font-size: 1.25rem;
+    font-weight: 500;
+}
+
 .skills-slider li[aria-hidden="false"]>.item i.devicon,
 .skills-slider li[aria-hidden="false"]>.item img.custom-skill-icon {
     filter: brightness(1) invert(0);

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -9,10 +9,12 @@ function App() {
     return (
         <div className="App">
             <NavBar />
-            <Hero />
-            <Skills />
-            <Projects />
-            <ContactMe />
+            <main>
+                <Hero />
+                <Skills />
+                <Projects />
+                <ContactMe />
+            </main>
             <Footer />
         </div>
     );

--- a/src/components/SkillsCarousel.tsx
+++ b/src/components/SkillsCarousel.tsx
@@ -219,7 +219,7 @@ const SkillsCarousel = () => {
                                 loading="lazy"
                             />
                         )}
-                        <h5>{skill.name}</h5>
+                        <span className="skill-name">{skill.name}</span>
                     </div>
                 );
             })}


### PR DESCRIPTION
## Summary

Three concrete failures from #38's audit, fixed in one pass.

### 1. Footer copyright color contrast
Was: `#757575` on `#1f1f1f` = **3.57:1** (needs 4.5).  
Now: `#a0a0a0` = **6.30:1** — comfortable AA pass.

### 2. Skills carousel heading order
Was: `<h5>` skill name following `<h2>Skills</h2>` — skipped levels.  
Skill names aren't structural section headings — they're labels for an icon.  
Now: `<span class="skill-name">` + matching CSS (`font-size: 1.25rem`, `font-weight: 500`, `display: block`) so the visual reads identically.

### 3. `<main>` landmark
Wrapped `Hero + Skills + Projects + ContactMe` in `<main>` inside `App.tsx`. `NavBar` and `Footer` stay outside (header / footer landmarks own their own roles).

## Verified

Lighthouse a11y **94 → 100**. All three previously-failing audits pass:
- color-contrast ✓
- heading-order ✓
- landmark-one-main ✓

## Test plan

- [ ] `npm run dev` — visually verify Skills carousel labels render at the same size + weight as before
- [ ] Footer copyright text is visibly readable on the dark background
- [ ] Screen reader announces "main" landmark when navigating page regions
- [ ] Build green: `npm run build` ✓
- [ ] Type check green: `npx tsc --noEmit` ✓
- [ ] Note: closes #121 won't auto-fire on dev merge — close manually after review