### PR TITLE
perf: Phase A quick wins — font-display, LCP priority, image dims (#122)

### DIFF
--- a/src/components/ContactMe.tsx
+++ b/src/components/ContactMe.tsx
@@ -26,6 +26,9 @@ const ContactMe = () => {
                                 <img
                                     src={contactImage}
                                     alt="Caricature of Miguel working at a laptop"
+                                    width={1592}
+                                    height={1592}
+                                    loading="lazy"
                                 />
                             </picture>
                         </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -19,6 +19,9 @@ const Hero = () => {
                                 className="floating-image"
                                 src={bitmojiSpacePlanet}
                                 alt="Floating Caricature"
+                                width={1592}
+                                height={1592}
+                                fetchPriority="high"
                             />
                         </picture>
                     </Col>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -168,6 +168,8 @@ const Projects = ({ initialInView = false }: ProjectsProps = {}) => {
                     alt=""
                     aria-hidden="true"
                     className="background-image-right"
+                    width={667}
+                    height={1064}
                     loading="lazy"
                 />
             </picture>

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -18,6 +18,8 @@ const Skills = () => {
                     alt=""
                     aria-hidden="true"
                     className="background-image-left"
+                    width={776}
+                    height={1064}
                     loading="lazy"
                 />
             </picture>

--- a/src/index.css
+++ b/src/index.css
@@ -5,18 +5,21 @@
   font-family: Centra;
   src: url("/src/assets/fonts/CentraNo2-Book.ttf");
   font-weight: 400;
+  font-display: swap;
 }
 
 @font-face {
   font-family: Centra;
   src: url("/src/assets/fonts/CentraNo2-Medium.ttf");
   font-weight: 500;
+  font-display: swap;
 }
 
 @font-face {
   font-family: Centra;
   src: url("/src/assets/fonts/CentraNo2-Bold.ttf");
   font-weight: 700;
+  font-display: swap;
 }
 
 :root {


### PR DESCRIPTION
## Summary

#122 Phase A — the structural quick wins. Three changes, no architecture work yet (that's Phase B).

### Changes
- **`font-display: swap`** on all three `CentraNo2` `@font-face` declarations. Eliminates invisible-text flash while custom fonts load.
- **Hero floating bitmoji** (Lighthouse-identified LCP element) gets `fetchPriority="high"` + explicit `width={1592} height={1592}`.
- **Width / height on remaining unsized images:** `bitmoji-laptop-2` in ContactMe, `color-pop` / `color-pop-2` backgrounds in Skills + Projects. Dimensions read from source PNGs (1592², 776×1064, 667×1064).

### Verified delta (Lighthouse perf-only, headless)

| Metric | Before | After |
|---|---|---|
| Performance score | 60 | 61 |
| CLS | 0.083 | **0** ✓ |
| LCP | ~11.2 s | ~11.4 s (variance) |
| FCP / SI | ~5.7 s | ~5.7 s |

Score barely moves because the dominant bottlenecks are the render-blocking JS/CSS bundle — that's Phase B. But CLS hitting 0 is a real win that Phase A locks in.

### Out of scope (Phase B — to be filed if pursued)
- Render-blocking + unused JS / CSS bundle reduction
- Code-splitting Projects / Skills sections via dynamic import
- Critical CSS inlining or preload `<link>` for hashed LCP asset
- Footer social-icon `<img>` flagged unsized but rendering at height 0 in Lighthouse (likely lazy-load timing) — separate investigation

## Test plan

- [ ] `npm run dev` — text renders without invisible-flash on first load (font-display: swap)
- [ ] Hero bitmoji loads visibly at the start of LCP window
- [ ] No layout shift while scrolling through Hero / Skills / Projects / Contact (CLS = 0)
- [ ] Build green: `npm run build` ✓
- [ ] Type check green: `npx tsc --noEmit` ✓
- [ ] Note: closes #122 won't auto-fire on dev merge — leave #122 open since Phase B is the remaining work