### PR TITLE
fix(contact): cap bitmoji at 480px so it doesn't sprawl on wide screens

### DIFF
--- a/src/assets/styles/Contact.css
+++ b/src/assets/styles/Contact.css
@@ -30,6 +30,7 @@
 
 .contact img {
     width: 92%;
+    max-width: 480px;
     filter: drop-shadow(3px 3px 42px rgba(155, 155, 155, 0.5));
     filter: drop-shadow(10px 14px 13px rgba(20, 20, 20, 0.8));
 }


### PR DESCRIPTION
## Summary

Standalone hotfix surfaced while reviewing the contact section. The bitmoji was rendering at ~600px+ on wide viewports because `.contact img` was `width: 92%` with no `max-width` — the responsive percentage works fine on mobile but at desktop widths the bitmoji took up too much vertical space and bled above the section visually.

Adding `max-width: 480px` caps the desktop size at a sensible value while keeping the 92% scaling on narrow screens.

## Test plan

- [ ] `npm run dev` — Contact section bitmoji at desktop widths fits within ~half-column without overflow
- [ ] Mobile view — bitmoji still scales to fit narrow column at 92%
- [ ] Build green: `npm run build` ✓