### PR TITLE
perf: critical-path trim (CSS -30%, hygiene fixes; score unchanged)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "lint-staged": "^16.4.0",
         "playwright": "^1.59.1",
         "png-to-ico": "^3.0.1",
+        "postcss-font-display": "^0.3.0",
         "prop-types": "^15.8.1",
         "puppeteer": "^24.42.0",
         "sharp": "^0.34.5",
@@ -11901,6 +11902,19 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-font-display": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-font-display/-/postcss-font-display-0.3.0.tgz",
+      "integrity": "sha512-vtvuIIkiwr8aliF+dQ+NyiagJ3pXs9Bnfr+ur1GvMxO59nqbyjUgYk7MjCWLIDQt1Si09I15l+Qu/vlozLgQbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.0"
       }
     },
     "node_modules/postcss-selector-parser": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "lint-staged": "^16.4.0",
     "playwright": "^1.59.1",
     "png-to-ico": "^3.0.1",
+    "postcss-font-display": "^0.3.0",
     "prop-types": "^15.8.1",
     "puppeteer": "^24.42.0",
     "sharp": "^0.34.5",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -6,9 +6,12 @@
 // - devicon-* per-skill icon classes built from data
 // - is-active / is-* / has-* state modifiers toggled by handlers
 // - react-multi-carousel internals
-// - aria-invalid="true" attribute selector targets
+// - [aria-*] attribute selectors (aria-invalid in ContactForm, aria-hidden in
+//   Skills carousel). NOT data-* — those over-pull bootstrap's
+//   [data-bs-popper] etc. that we don't use.
 
 import purgeCssPkg from '@fullhuman/postcss-purgecss';
+import postcssFontDisplay from 'postcss-font-display';
 const purgeCSSPlugin = purgeCssPkg.purgeCSSPlugin || purgeCssPkg.default || purgeCssPkg;
 
 export default {
@@ -36,10 +39,17 @@ export default {
                               /^collapsing$/,
                               /^collapse$/
                           ],
-                          deep: [/^modal/, /^dropdown/, /^tooltip/, /^popover/],
-                          greedy: [/aria-/, /data-/]
-                      }
-                  })
+                          greedy: [/\[aria-/]
+                      },
+                      // Bootstrap classes whose names match unrelated prose
+                      // substrings ("segmented-progress" pulls .progress,
+                      // descriptions like "carousel of devicons" pull .carousel).
+                      // None of these components are used in the app.
+                  }),
+                  // Force font-display: swap on every @font-face — overrides
+                  // devicon's font-display: block to eliminate FOIT in the
+                  // Skills section. replace: true rewrites existing values.
+                  postcssFontDisplay({ display: 'swap', replace: true })
               ]
             : []
 };

--- a/src/components/HeroContent.tsx
+++ b/src/components/HeroContent.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ArrowRightCircle } from 'react-bootstrap-icons';
-import { useInView } from 'react-intersection-observer';
 
 const HeroContent = () => {
-    const { ref, inView } = useInView({ triggerOnce: true });
+    const ref = useRef<HTMLDivElement | null>(null);
+    const [inView, setInView] = useState(false);
     const [isTyping, setIsTyping] = useState(true);
     const [jobTitle, setJobTitle] = useState('');
     const [roleCount, setRoleCount] = useState(0);
@@ -12,40 +12,61 @@ const HeroContent = () => {
     const pauseTime = 3456; // time between typing and deleting
     const yearsOfExp = new Date().getFullYear() - 2016;
 
-    const doTyping = () => {
-        const currentRole = roleCount % roles.length;
-        const fullText = roles[currentRole];
-        const currentText = isTyping
-            ? fullText.substring(0, jobTitle.length + 1)
-            : fullText.substring(0, jobTitle.length - 1);
-
-        setJobTitle(currentText);
-
-        if (!isTyping) {
-            // set how fast we delete characters
-            setTypingDelay(100);
-        }
-
-        if (isTyping && currentText === fullText) {
-            setIsTyping(false);
-            setTypingDelay(pauseTime);
-        } else if (!isTyping && currentText === '') {
-            setIsTyping(true);
-            setRoleCount(roleCount + 1);
-            setTypingDelay(321);
-        }
-    };
-
+    // Native IntersectionObserver replaces react-intersection-observer to keep
+    // the lib out of the main bundle (Skills/Projects/ContactMe lazy chunks
+    // still use it). triggerOnce: disconnect after first hit.
     useEffect(() => {
-        const typingTicker = setInterval(() => {
-            doTyping();
-        }, typingDelay);
+        const el = ref.current;
+        if (!el) return;
+        if (typeof IntersectionObserver === 'undefined') {
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            setInView(true);
+            return;
+        }
+        const io = new IntersectionObserver(([entry]) => {
+            if (entry.isIntersecting) {
+                setInView(true);
+                io.disconnect();
+            }
+        });
+        io.observe(el);
+        return () => io.disconnect();
+    }, []);
 
-        return () => {
-            clearInterval(typingTicker);
+    // doTyping reads four state values via closure. Stash the latest closure
+    // in a ref and have the interval call ref.current() so the interval only
+    // recreates when typingDelay changes (3 times per cycle: type→pause→delete),
+    // not on every keystroke.
+    const doTypingRef = useRef<() => void>(() => {});
+    useEffect(() => {
+        doTypingRef.current = () => {
+            const currentRole = roleCount % roles.length;
+            const fullText = roles[currentRole];
+            const currentText = isTyping
+                ? fullText.substring(0, jobTitle.length + 1)
+                : fullText.substring(0, jobTitle.length - 1);
+
+            setJobTitle(currentText);
+
+            if (!isTyping) {
+                setTypingDelay(100);
+            }
+
+            if (isTyping && currentText === fullText) {
+                setIsTyping(false);
+                setTypingDelay(pauseTime);
+            } else if (!isTyping && currentText === '') {
+                setIsTyping(true);
+                setRoleCount(roleCount + 1);
+                setTypingDelay(321);
+            }
         };
     });
-    // }, [jobTitle]);
+
+    useEffect(() => {
+        const typingTicker = setInterval(() => doTypingRef.current(), typingDelay);
+        return () => clearInterval(typingTicker);
+    }, [typingDelay]);
 
     return (
         <div

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -62,6 +62,7 @@ const NavBar = () => {
 
     // Scroll spy: active link = last section whose top edge is at or above the trigger line.
     // Monotonic — won't oscillate as sections enter/exit the viewport.
+    // Listener attaches via requestIdleCallback so it doesn't compete with LCP.
     useEffect(() => {
         const sectionIds = navLinks.map(({ name }) => name);
 
@@ -81,8 +82,27 @@ const NavBar = () => {
         };
 
         onScroll();
-        window.addEventListener('scroll', onScroll, { passive: true });
-        return () => window.removeEventListener('scroll', onScroll);
+        const w = window as unknown as {
+            requestIdleCallback?: typeof requestIdleCallback;
+            cancelIdleCallback?: typeof cancelIdleCallback;
+        };
+        const ric = w.requestIdleCallback;
+        const cic = w.cancelIdleCallback;
+        let idleHandle: number | undefined;
+        let timeoutHandle: number | undefined;
+        const attach = () => {
+            window.addEventListener('scroll', onScroll, { passive: true });
+        };
+        if (ric) {
+            idleHandle = ric(attach, { timeout: 2000 });
+        } else {
+            timeoutHandle = window.setTimeout(attach, 1);
+        }
+        return () => {
+            if (idleHandle !== undefined && cic) cic(idleHandle);
+            if (timeoutHandle !== undefined) window.clearTimeout(timeoutHandle);
+            window.removeEventListener('scroll', onScroll);
+        };
     }, []);
 
     const handleToggle = () => {


### PR DESCRIPTION
## Summary

Hygiene PR. Trims the critical render path and cleans up two always-rendered components. Honest framing up front: **Lighthouse perf score stayed at 61** — the cap is React mount time on simulated mobile CPU, not bytes (memory's "70 needs SSR" call). Wins are real but score-invisible.

### What shipped

| Change | Real impact |
|---|---|
| PurgeCSS deep safelist removed; greedy narrowed to `[/\[aria-/]` | Main CSS 79 → 55 KB (-30%, 16.47 → 12.85 KB gzipped) |
| `postcss-font-display` plugin forces `font-display: swap` on every `@font-face` | Eliminates Devicon FOIT in the Skills lazy chunk |
| `react-intersection-observer` → native `IntersectionObserver` in HeroContent | ~3 KB shaved from main JS bundle |
| Typing useEffect refactored | Stops recreating `setInterval` every keystroke (was: no deps array) |
| NavBar scroll-spy attaches via `requestIdleCallback` (setTimeout fallback for Safari) | Removes `getElementById × 4 + getBoundingClientRect` from critical-path execution |

### Why the score didn't move

Phase 0 baseline confirmed the LCP element is the bitmoji `<img>`. Phase 1 made the bitmoji's network load near-instant — the `lcp-breakdown-insight` "resource load delay" dropped from **9.2s → 10ms**. But the measured LCP audit stays at 11.5s, which means the bottleneck is React mount time before the `<picture>` element renders. Pure JS execution on the 4× CPU throttle. SSR/SSG ceiling.

Centra fonts (the original Phase 2 target) won't help either — same reason. Fonts compete for bandwidth, but the LCP critical path is React mount, not network.

### Skipped from the original plan
- **1.2 Preload Centra fonts** — would have *worsened* LCP by competing with the bitmoji preload for connection slots. Phase 0 LCP-discovery checklist confirmed the bitmoji is already preloaded correctly.
- **PurgeCSS `blocklist`** — `.alert`/`.badge`/`.carousel`/`.progress` survive the purge because `"segmented-progress"` (in FeaturedImageSlider's indicator literal) and prose like "carousel of devicons" in story descriptions are picked up by PurgeCSS's content scan. Tried `blocklist: [/^\.(alert|badge|carousel|progress)/]` — the standalone PurgeCSS API honors it (verified) but the option doesn't take effect through Vite's PostCSS pipeline. Not worth chasing further; the 30% CSS shave we got is the bulk of the available win.

## Test plan

- [x] `npm run build` clean (CSS 79 → 55 KB)
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run --project storybook` 95/95 pass
- [x] Lighthouse mobile (simulate, headless): perf 61, a11y 100, BP 96, SEO 100 — unchanged
- [ ] Smoke-test prod preview in incognito browser: hero animation, navbar collapse, scroll spy, all skill icons paint without FOIT