### PR TITLE
fix(tests): unbreak App + ContactForm unit tests (122 → 126/126)

### DIFF
--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -2,15 +2,18 @@ import { render, screen } from '@testing-library/react';
 import App from './App';
 
 describe('App', () => {
-    test('renders without crashing and mounts every section', () => {
+    // Skills, Projects, and ContactMe are code-split via React.lazy + Suspense
+    // (App.tsx). Use findByRole so the assertions wait for each chunk to
+    // resolve before querying.
+    test('renders without crashing and mounts every section', async () => {
         render(<App />);
-        // Hero
+        // Hero (eager)
         expect(screen.getByRole('heading', { name: /Hi, I'm Miguel!/i })).toBeInTheDocument();
-        // Skills
-        expect(screen.getByRole('heading', { name: /^Skills$/i })).toBeInTheDocument();
-        // Projects
-        expect(screen.getByRole('heading', { name: /^Projects$/i })).toBeInTheDocument();
-        // Contact (rendered twice — h2 + h3 for responsive variants)
-        expect(screen.getAllByRole('heading', { name: /Wanna Hire Me/i }).length).toBeGreaterThan(0);
+        // Three lazy chunks resolve in parallel; default 1s findBy timeout
+        // is flaky on slower CI. 5s is plenty.
+        const opts = { timeout: 5000 };
+        expect(await screen.findByRole('heading', { name: /^Skills$/i }, opts)).toBeInTheDocument();
+        expect(await screen.findByRole('heading', { name: /^Projects$/i }, opts)).toBeInTheDocument();
+        expect((await screen.findAllByRole('heading', { name: /Wanna Hire Me/i }, opts)).length).toBeGreaterThan(0);
     });
 });

--- a/src/components/ContactForm.test.tsx
+++ b/src/components/ContactForm.test.tsx
@@ -39,7 +39,7 @@ describe('ContactForm', () => {
         await user.type(screen.getByPlaceholderText(/Last Name/i), 'Lozano');
         await user.type(screen.getByPlaceholderText(/Email Address/i), 'a@b.com');
         await user.type(screen.getByPlaceholderText(/Phone Number/i), '5555550100');
-        await user.type(screen.getByPlaceholderText(/Message/i), 'Hello!');
+        await user.type(screen.getByPlaceholderText(/Message/i), 'Hello there, this is a long enough message.');
     };
 
     test('submits Web3Forms payload and shows success message', async () => {
@@ -62,7 +62,7 @@ describe('ContactForm', () => {
         expect(payload.access_key).toBeDefined();
         expect(payload.firstName).toBe('Miguel');
         expect(payload.email).toBe('a@b.com');
-        expect(payload.message).toBe('Hello!');
+        expect(payload.message).toBe('Hello there, this is a long enough message.');
         expect(payload.botcheck).toBe('');
 
         await waitFor(() => {


### PR DESCRIPTION
## Summary

Two pre-existing unit test failures on dev (4 reds total) — fixing both. Tests are now stable at 126/126 across 5 consecutive runs.

### App.test.tsx (1 failure)

`Skills`, `Projects`, and `ContactMe` are code-split via `React.lazy` + `Suspense` ([App.tsx:11-13](../blob/dev/src/components/App.tsx#L11-L13)). The test was using synchronous `getByRole` to query their headings, which can't see the lazy chunk content until it resolves. Switched to `findByRole` with a 5s timeout (default 1s was flaky on slower runs).

### ContactForm.test.tsx (3 failures)

The 3 submission-flow tests filled the message field with `'Hello!'` (6 chars). [ContactForm.tsx:28](../blob/dev/src/components/ContactForm.tsx#L28) validates `MESSAGE_MIN_LENGTH = 20`, so submit was being blocked by validation and `axios.post` never fired. The min-length validation was added in #115 (memory note); the tests predate it.

Used a 44-char message instead and updated the payload assertion accordingly.

## Test plan

- [x] `npm test` — 126/126 across 5 consecutive runs
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean