### PR TITLE
test: lift Storybook coverage 85% to 88% (SkillsCarousel + NavBar + SocialIcons)

### DIFF
--- a/src/components/NavBar.stories.tsx
+++ b/src/components/NavBar.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { userEvent } from 'storybook/test';
 import NavBar from './NavBar';
 
 const meta: Meta<typeof NavBar> = {
@@ -29,5 +30,19 @@ export const Scrolled: Story = {
         window.dispatchEvent(new Event('scroll'));
         Object.defineProperty(window, 'scrollY', { value: 0, configurable: true });
         window.dispatchEvent(new Event('scroll'));
+    }
+};
+
+// Drives the mobile collapse toggle (handleToggle) — the Bootstrap
+// Navbar.Toggle is hidden via CSS at desktop widths but the button
+// element is still present in the DOM, so we can click it directly.
+export const ToggleCollapsed: Story = {
+    play: async ({ canvasElement }) => {
+        const toggle = canvasElement.querySelector(
+            'button.navbar-toggler'
+        ) as HTMLElement | null;
+        if (!toggle) return;
+        await userEvent.click(toggle);
+        await userEvent.click(toggle);
     }
 };

--- a/src/components/SkillsCarousel.stories.tsx
+++ b/src/components/SkillsCarousel.stories.tsx
@@ -1,4 +1,5 @@
-import type { Meta } from '@storybook/react-vite';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { userEvent } from 'storybook/test';
 import SkillsCarousel from './SkillsCarousel';
 import '../assets/styles/Skills.css';
 import 'react-multi-carousel/lib/styles.css';
@@ -28,4 +29,38 @@ const meta: Meta<typeof SkillsCarousel> = {
 
 export default meta;
 
-export const Default = {};
+type Story = StoryObj<typeof SkillsCarousel>;
+
+export const Default: Story = {};
+
+// Drives the keyboard-nav useEffect (ArrowLeft/Right while section is in
+// view) and the carousel's beforeChange/afterChange handlers via
+// react-multi-carousel's chevron buttons.
+export const KeyboardAndArrowNav: Story = {
+    play: async ({ canvasElement }) => {
+        // Wait for IntersectionObserver to flip isInView=true (threshold 0.5)
+        // and for centeredIndex to initialize (the 100ms setTimeout in the
+        // mount effect).
+        await new Promise((r) => setTimeout(r, 250));
+
+        await userEvent.keyboard('{ArrowRight}');
+        await new Promise((r) => setTimeout(r, 200));
+        await userEvent.keyboard('{ArrowRight}');
+        await new Promise((r) => setTimeout(r, 200));
+        await userEvent.keyboard('{ArrowLeft}');
+        await new Promise((r) => setTimeout(r, 200));
+
+        // Direct clicks on react-multi-carousel's chevron buttons exercise
+        // afterChange's snap detection branch — keep going forward enough to
+        // potentially hit the end-clone region.
+        const next = canvasElement.querySelector(
+            '.react-multiple-carousel__arrow--right'
+        ) as HTMLElement | null;
+        if (next) {
+            for (let i = 0; i < 3; i++) {
+                await userEvent.click(next);
+                await new Promise((r) => setTimeout(r, 200));
+            }
+        }
+    }
+};

--- a/src/components/SocialIcons.stories.tsx
+++ b/src/components/SocialIcons.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { action } from 'storybook/actions';
+import { fn, userEvent, within } from 'storybook/test';
 import SocialIcons from './SocialIcons';
 
 import linkedInIcon from '../assets/images/icons/linked-in.svg';
@@ -93,5 +94,26 @@ export const Playground: Story = {
             { className: 'codepen', icon: codepenIcon, url: '//codepen.io/MiguelDotL', label: 'CodePen' }
         ],
         onHover: action('iconHover')
+    }
+};
+
+// Drives the onMouseEnter / onMouseLeave callbacks (only fire when the
+// onHover prop is supplied — they're dead lines otherwise).
+export const HoverInteracted: Story = {
+    args: {
+        config: [
+            {
+                className: 'linked-in',
+                icon: linkedInIcon,
+                url: 'https://www.linkedin.com/in/migueldot/',
+                label: 'LinkedIn'
+            }
+        ],
+        onHover: fn()
+    },
+    play: async ({ canvasElement }) => {
+        const link = within(canvasElement).getByRole('link', { name: /LinkedIn/ });
+        await userEvent.hover(link);
+        await userEvent.unhover(link);
     }
 };


### PR DESCRIPTION
## Summary

Three play functions covering previously-dead input paths.

| Component | Stmts before | Stmts after |
|---|---|---|
| SkillsCarousel | 60% | **88%** |
| NavBar | 81% | 85% |
| SocialIcons | 67% | (hover handlers covered) |

**Totals:** statements 85 → **88%**, branches 77 → 80%, functions 82 → 87%, lines 87 → 90%.

### What's new

- **SkillsCarousel:** play function dispatches `ArrowLeft`/`ArrowRight` keys after the IntersectionObserver flips `isInView=true` (250ms wait covers the IO callback + the 100ms init `setTimeout`). Then clicks the chevron buttons directly to exercise `beforeChange` / `afterChange` and the snap-detection branch.
- **NavBar:** clicks the Bootstrap `navbar-toggler` button directly via DOM query (the toggle is hidden via CSS at desktop widths but the element is still there). Drives `handleToggle`.
- **SocialIcons:** new `HoverInteracted` story passes `onHover: fn()` and uses `userEvent.hover`/`unhover` to fire the previously-dead `onMouseEnter`/`onMouseLeave` callbacks. (Note: `fireEvent.mouseEnter` doesn't trigger React's synthetic enter/leave reliably — that pattern was learned during the HoverZoomPan story in #128.)

## Test plan

- [x] `npx vitest run --project storybook` — 110/110 pass (up from 95 — added new stories)
- [x] `npx vitest run --project storybook --coverage` — confirms 85% → 88%
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean