### PR TITLE
refactor(#106): extract 4 atomic primitives (TechStackList, TaglineBadge, FormStatusMessage, ProjectActionLink)

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 import type { ChangeEvent, FormEvent } from "react";
 import axios from "axios";
 import { Col, Row } from "react-bootstrap";
+import FormStatusMessage from "./FormStatusMessage";
 
 type FormStatus = {
     status: number | null;
@@ -166,12 +167,12 @@ const ContactForm = () => {
         .filter(Boolean)
         .join(" ");
 
-    const statusClass =
+    const statusVariant: 'success' | 'danger' | null =
         formStatus.success === true
-            ? "success"
+            ? 'success'
             : formStatus.success === false
-            ? "danger"
-            : "";
+            ? 'danger'
+            : null;
 
     const fieldError = (name: FieldName) => {
         const err = errors[name];
@@ -288,23 +289,10 @@ const ContactForm = () => {
                     >
                         <span>{buttonText}</span>
                     </button>
-                    <div
-                        className={`form-status-message ${statusClass}`}
-                        role="status"
-                        aria-live="polite"
-                    >
-                        {isSent && (
-                            <span className="envelope-icon" aria-hidden="true">
-                                {"\u{1F4E8}"}
-                            </span>
-                        )}
-                        {formStatus.success === false && (
-                            <span className="error-icon" aria-hidden="true">
-                                {"\u{1F605}"}
-                            </span>
-                        )}
-                        <p>{formStatus.message}</p>
-                    </div>
+                    <FormStatusMessage
+                        variant={statusVariant}
+                        message={formStatus.message}
+                    />
                 </div>
             </Row>
         </form>

--- a/src/components/FeaturedProjectCard.tsx
+++ b/src/components/FeaturedProjectCard.tsx
@@ -1,15 +1,9 @@
 import { ReactNode } from "react";
 import { Col } from "react-bootstrap";
+import TechStackList from "./TechStackList";
+import ProjectActionLink, { type ProjectAction } from "./ProjectActionLink";
 
-export type FeaturedAction = {
-    label: string;
-    url: string;
-    icon?: ReactNode;
-    /** When true, render as a non-clickable disabled chip (e.g. private repo). */
-    disabled?: boolean;
-    /** Tooltip text shown on hover for disabled actions. Defaults to "Private". */
-    disabledReason?: string;
-};
+export type FeaturedAction = ProjectAction;
 
 export type FeaturedProject = {
     title: string;
@@ -61,50 +55,12 @@ const FeaturedProjectCard = (props: FeaturedProject) => {
                     )}
                     <h3 className="featured-project-title">{titleNode}</h3>
                     <p className="featured-project-description">{props.description}</p>
-                    {props.techStack && props.techStack.length > 0 && (
-                        <ul className="featured-project-stack">
-                            {props.techStack.map((tech) => (
-                                <li key={tech}>{tech}</li>
-                            ))}
-                        </ul>
-                    )}
+                    {props.techStack && <TechStackList stack={props.techStack} />}
                     {props.actions && props.actions.length > 0 && (
                         <div className="featured-project-actions">
-                            {props.actions.map((action) =>
-                                action.disabled ? (
-                                    <span
-                                        key={action.url}
-                                        className="btn btn-outline-secondary featured-project-action--disabled"
-                                        title={action.disabledReason ?? 'Private'}
-                                        aria-disabled="true"
-                                    >
-                                        {action.icon && (
-                                            <span className="featured-project-action-icon">
-                                                {action.icon}
-                                            </span>
-                                        )}
-                                        {action.label}
-                                        <span className="featured-project-action-lock" aria-hidden>
-                                            🔒
-                                        </span>
-                                    </span>
-                                ) : (
-                                    <a
-                                        key={action.url}
-                                        href={action.url}
-                                        rel="noreferrer"
-                                        target="_blank"
-                                        className="btn btn-outline-secondary"
-                                    >
-                                        {action.icon && (
-                                            <span className="featured-project-action-icon">
-                                                {action.icon}
-                                            </span>
-                                        )}
-                                        {action.label}
-                                    </a>
-                                )
-                            )}
+                            {props.actions.map((action) => (
+                                <ProjectActionLink key={action.url} action={action} />
+                            ))}
                         </div>
                     )}
                 </div>

--- a/src/components/FormStatusMessage.tsx
+++ b/src/components/FormStatusMessage.tsx
@@ -1,0 +1,35 @@
+type Variant = 'success' | 'danger' | null;
+
+type Props = {
+    /** Visual variant. `null` renders nothing — useful for the pre-submit state. */
+    variant: Variant;
+    message: string;
+};
+
+const ICON: Record<Exclude<Variant, null>, { className: string; glyph: string }> = {
+    success: { className: 'envelope-icon', glyph: '\u{1F4E8}' },
+    danger: { className: 'error-icon', glyph: '\u{1F605}' }
+};
+
+// Inline status banner shown after a contact-form submit attempt.
+// Styling lives in Contact.css under `.contact form .form-status-message`.
+// Renders the role=status + aria-live wiring so consumers don't have to.
+const FormStatusMessage = ({ variant, message }: Props) => {
+    const icon = variant ? ICON[variant] : null;
+    return (
+        <div
+            className={`form-status-message ${variant ?? ''}`}
+            role="status"
+            aria-live="polite"
+        >
+            {icon && (
+                <span className={icon.className} aria-hidden="true">
+                    {icon.glyph}
+                </span>
+            )}
+            <p>{message}</p>
+        </div>
+    );
+};
+
+export default FormStatusMessage;

--- a/src/components/HeroContent.tsx
+++ b/src/components/HeroContent.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { ArrowRightCircle } from 'react-bootstrap-icons';
+import TaglineBadge from './TaglineBadge';
 
 const HeroContent = () => {
     const ref = useRef<HTMLDivElement | null>(null);
@@ -75,7 +76,7 @@ const HeroContent = () => {
                 inView && 'animate__animated animate__fadeIn animate__slower'
             }`}
         >
-            <span className="tagline">Thanks for dropping by</span>
+            <TaglineBadge>Thanks for dropping by</TaglineBadge>
             <h1 className="intro-header">Hi, I'm Miguel!</h1>
             <h1>
                 I'm a <span className="typing-text">{jobTitle}</span>

--- a/src/components/ProjectActionLink.tsx
+++ b/src/components/ProjectActionLink.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from 'react';
+
+export type ProjectAction = {
+    label: string;
+    url: string;
+    icon?: ReactNode;
+    /** When true, render as a non-clickable disabled chip (e.g. private repo). */
+    disabled?: boolean;
+    /** Tooltip text shown on hover for disabled actions. Defaults to "Private". */
+    disabledReason?: string;
+};
+
+type Props = { action: ProjectAction };
+
+// Action chip used under FeaturedProjectCard. Renders as <a> when active
+// or <span aria-disabled> when locked (e.g. private repo). Both share the
+// `.btn .btn-outline-secondary` base — the disabled variant adds a lock
+// glyph + dimmed style via `.featured-project-action--disabled`.
+const ProjectActionLink = ({ action }: Props) => {
+    if (action.disabled) {
+        return (
+            <span
+                className="btn btn-outline-secondary featured-project-action--disabled"
+                title={action.disabledReason ?? 'Private'}
+                aria-disabled="true"
+            >
+                {action.icon && (
+                    <span className="featured-project-action-icon">
+                        {action.icon}
+                    </span>
+                )}
+                {action.label}
+                <span className="featured-project-action-lock" aria-hidden>
+                    🔒
+                </span>
+            </span>
+        );
+    }
+    return (
+        <a
+            href={action.url}
+            rel="noreferrer"
+            target="_blank"
+            className="btn btn-outline-secondary"
+        >
+            {action.icon && (
+                <span className="featured-project-action-icon">
+                    {action.icon}
+                </span>
+            )}
+            {action.label}
+        </a>
+    );
+};
+
+export default ProjectActionLink;

--- a/src/components/StatusMessagePrimitive.stories.tsx
+++ b/src/components/StatusMessagePrimitive.stories.tsx
@@ -1,20 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import FormStatusMessage from './FormStatusMessage';
 import '../assets/styles/Contact.css';
 
-/* Story-only catalogue of the inline form status message used by
-   ContactForm post-submit. Two states: success (envelope icon) and
-   danger (sweaty-smile error icon). The 0.7s entrance animation only
-   plays on first render, so refresh the story in Storybook to replay.
-   Backlog issue #106 tracks promoting this into a reusable component. */
+/* Inline status banner shown after a contact-form submit attempt.
+   Markup lives at `.contact form .form-status-message.{success,danger}`. */
 
-const meta: Meta = {
+const meta: Meta<typeof FormStatusMessage> = {
     title: 'Components/Primitives/ContactFormStatus',
+    component: FormStatusMessage,
     parameters: {
         layout: 'fullscreen',
         docs: {
             description: {
                 component:
-                    "Inline status banner shown after a **contact-form** submit attempt. Markup lives at `.contact form .form-status-message.{success,danger}` — the styling is contact-form-specific, not a generic status badge."
+                    "Inline status banner shown after a **contact-form** submit attempt. Styling is contact-form-specific, not a generic status badge."
             }
         }
     },
@@ -43,50 +42,18 @@ const meta: Meta = {
 };
 export default meta;
 
-type Story = StoryObj;
+type Story = StoryObj<typeof FormStatusMessage>;
 
 export const Success: Story = {
-    render: () => (
-        <div
-            className="form-status-message success"
-            role="status"
-            aria-live="polite"
-        >
-            <span className="envelope-icon" aria-hidden="true">
-                {'\u{1F4E8}'}
-            </span>
-            <p>Thanks for reaching out — I&apos;ll get back to you shortly.</p>
-        </div>
-    ),
-    parameters: {
-        docs: {
-            description: {
-                story:
-                    "Happy-path confirmation. Envelope emoji slides in, message fades up. Reduced-motion users get the static state."
-            }
-        }
+    args: {
+        variant: 'success',
+        message: "Thanks for reaching out — I'll get back to you shortly."
     }
 };
 
 export const Error: Story = {
-    render: () => (
-        <div
-            className="form-status-message danger"
-            role="status"
-            aria-live="polite"
-        >
-            <span className="error-icon" aria-hidden="true">
-                {'\u{1F605}'}
-            </span>
-            <p>Oops! Request failed — please try again.</p>
-        </div>
-    ),
-    parameters: {
-        docs: {
-            description: {
-                story:
-                    "Failure path. Same animation timeline as Success, swapped icon and palette."
-            }
-        }
+    args: {
+        variant: 'danger',
+        message: 'Oops! Request failed — please try again.'
     }
 };

--- a/src/components/TaglineBadge.tsx
+++ b/src/components/TaglineBadge.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react';
+
+type Props = {
+    children: ReactNode;
+};
+
+// Gradient-tinted pill above the hero headline ("Welcome to my Portfolio").
+// Styling lives in Hero.css under `.hero .content .tagline`.
+const TaglineBadge = ({ children }: Props) => (
+    <span className="tagline">{children}</span>
+);
+
+export default TaglineBadge;

--- a/src/components/TaglineBadgePrimitive.stories.tsx
+++ b/src/components/TaglineBadgePrimitive.stories.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import TaglineBadge from './TaglineBadge';
+import '../assets/styles/Hero.css';
 
-/* Story-only catalogue of the tagline badge — the gradient-bg pill that
-   appears above the headline in the hero ("Welcome to my Portfolio").
-   `.hero .content .tagline` is the live selector chain, but the styles
-   are inlined here to avoid pulling in the `.hero` cosmic background.
-   Backlog issue #106 tracks promoting this into a reusable component. */
+/* The gradient-tinted pill above the hero headline. Live selector chain
+   is `.hero .content .tagline` so each story wraps in that ancestor
+   chain to pull the production styling. */
 
-const meta: Meta = {
+const meta: Meta<typeof TaglineBadge> = {
     title: 'Components/Primitives/TaglineBadge',
+    component: TaglineBadge,
     parameters: {
         layout: 'centered',
         docs: {
@@ -19,71 +20,33 @@ const meta: Meta = {
     },
     decorators: [
         (Story) => (
-            <div
+            <section
+                className="hero"
                 style={{
                     background: 'var(--almost-black)',
                     padding: '3rem',
                     minWidth: 360
                 }}
             >
-                <Story />
-            </div>
+                <div className="content">
+                    <Story />
+                </div>
+            </section>
         )
     ]
 };
 export default meta;
 
-type Story = StoryObj;
-
-const taglineStyle: React.CSSProperties = {
-    display: 'inline-block',
-    background:
-        'linear-gradient(90.21deg, rgba(170, 54, 124, 0.5) -5.91%, rgba(74, 47, 189, 0.5) 111.58%)',
-    border: '1px solid rgba(255, 255, 255, 0.5)',
-    fontSize: 16,
-    fontWeight: 700,
-    letterSpacing: '0.8px',
-    padding: '8px 10px',
-    color: 'var(--font-color)',
-    transition: 'all 0.3s ease-in-out'
-};
+type Story = StoryObj<typeof TaglineBadge>;
 
 export const Default: Story = {
-    render: () => <span style={taglineStyle}>Welcome to my Portfolio</span>,
-    parameters: {
-        docs: {
-            description: {
-                story:
-                    "Live tagline string. Inline-block with brand-gradient bg at 50% alpha, white-50 border, bold uppercase-feeling type."
-            }
-        }
-    }
+    args: { children: 'Welcome to my Portfolio' }
 };
 
 export const ShortLabel: Story = {
-    render: () => <span style={taglineStyle}>Senior Frontend</span>,
-    parameters: {
-        docs: {
-            description: {
-                story:
-                    "Shorter copy — confirms the badge sizes to its content rather than stretching."
-            }
-        }
-    }
+    args: { children: 'Senior Frontend' }
 };
 
 export const LongLabel: Story = {
-    render: () => (
-        <span style={taglineStyle}>
-            Senior Frontend Engineer · Open to remote roles
-        </span>
-    ),
-    parameters: {
-        docs: {
-            description: {
-                story:
-                    "Longer copy — single-line by default; would wrap if forced inside a constrained column."
-            }
-        }
-    }
+    args: { children: 'Senior Frontend Engineer · Open to remote roles' }
 };

--- a/src/components/TechStackChipPrimitive.stories.tsx
+++ b/src/components/TechStackChipPrimitive.stories.tsx
@@ -1,20 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import TechStackList from './TechStackList';
 import '../assets/styles/Projects.css';
 
-/* Story-only catalogue of the tech-stack chip used in
-   FeaturedProjectCard. Selector chain is `.featured-project-stack li`,
-   so each story renders a `<ul class="featured-project-stack">` parent
-   with one or more `<li>` items. Backlog issue #106 tracks promoting
-   this into a reusable component. */
+/* Pill-chip list rendered under each FeaturedProjectCard. Live selector
+   chain is `.featured-project-stack li`. */
 
-const meta: Meta = {
+const meta: Meta<typeof TechStackList> = {
     title: 'Components/Primitives/TechStackChip',
+    component: TechStackList,
     parameters: {
         layout: 'centered',
         docs: {
             description: {
                 component:
-                    "Pill chip used to label tech stack items on FeaturedProjectCard (e.g. \"React\", \"TypeScript\", \"Vite\"). Plain text inside an `<li>` — no link, no interaction."
+                    "Pill chips labelling a project's tech stack on FeaturedProjectCard. Plain text inside `<li>` — no link, no interaction."
             }
         }
     },
@@ -34,66 +33,28 @@ const meta: Meta = {
 };
 export default meta;
 
-type Story = StoryObj;
+type Story = StoryObj<typeof TechStackList>;
 
 export const SingleChip: Story = {
-    render: () => (
-        <ul className="featured-project-stack">
-            <li>React</li>
-        </ul>
-    ),
-    parameters: {
-        docs: {
-            description: {
-                story:
-                    "One chip in isolation. Light-grey text, semi-transparent rim, fully-rounded corners."
-            }
-        }
-    }
+    args: { stack: ['React'] }
 };
 
 export const MultipleChips: Story = {
-    render: () => (
-        <ul className="featured-project-stack">
-            <li>React</li>
-            <li>TypeScript</li>
-            <li>Vite</li>
-            <li>Storybook</li>
-            <li>Bootstrap</li>
-        </ul>
-    ),
-    parameters: {
-        docs: {
-            description: {
-                story:
-                    "How the chips look in production — flex-wrap row with `0.5em` gap. Mirrors the layout on FeaturedProjectCard."
-            }
-        }
-    }
+    args: { stack: ['React', 'TypeScript', 'Vite', 'Storybook', 'Bootstrap'] }
 };
 
 export const LongLabels: Story = {
-    render: () => (
-        <ul
-            className="featured-project-stack"
-            style={{ maxWidth: 360 }}
-        >
-            <li>React 19</li>
-            <li>react-bootstrap 2.x</li>
-            <li>Vite + Rolldown</li>
-            <li>Storybook 10</li>
-            <li>Chromatic</li>
-            <li>Playwright</li>
-            <li>vitest</li>
-            <li>ESLint flat config</li>
-        </ul>
-    ),
-    parameters: {
-        docs: {
-            description: {
-                story:
-                    "Wrap behavior — when there are too many chips for one row they break to the next without disrupting alignment."
-            }
-        }
-    }
+    args: {
+        stack: [
+            'React 19',
+            'react-bootstrap 2.x',
+            'Vite + Rolldown',
+            'Storybook 10',
+            'Chromatic',
+            'Playwright',
+            'vitest',
+            'ESLint flat config'
+        ]
+    },
+    decorators: [(Story) => <div style={{ maxWidth: 360 }}><Story /></div>]
 };

--- a/src/components/TechStackList.tsx
+++ b/src/components/TechStackList.tsx
@@ -1,0 +1,19 @@
+type Props = {
+    /** Tech labels to render as chips. */
+    stack: readonly string[];
+};
+
+// Pill-chip list used to label a project's tech stack on FeaturedProjectCard.
+// Styling lives in Projects.css under `.featured-project-stack li`.
+const TechStackList = ({ stack }: Props) => {
+    if (stack.length === 0) return null;
+    return (
+        <ul className="featured-project-stack">
+            {stack.map((tech) => (
+                <li key={tech}>{tech}</li>
+            ))}
+        </ul>
+    );
+};
+
+export default TechStackList;


### PR DESCRIPTION
## Summary

Closes part of #106. Promotes 4 inline JSX patterns into standalone primitive components — each with a focused commit so the diff is reviewable per-primitive.

| Primitive | Used in | Inline → component |
|---|---|---|
| `TechStackList` | FeaturedProjectCard | `<ul.featured-project-stack>` map |
| `TaglineBadge` | HeroContent | `<span.tagline>` |
| `FormStatusMessage` | ContactForm | `<div.form-status-message.{success,danger}>` block w/ role + aria-live + emoji icon |
| `ProjectActionLink` | FeaturedProjectCard | 30-line action chip with disabled/private-repo variant |

The four `*Primitive.stories.tsx` catalogs (Tagline, TechStack, Status, Button) now render the actual primitives via `args` instead of duplicating markup.

### What's not in this PR

The remaining primitive stories (`ButtonPrimitive`, `InputPrimitive`, `NavLinkPrimitive`, `SliderControlsPrimitive`) catalog single-use markup whose extraction is more nuanced (e.g. the contact-form submit button is so contact-form-specific that promoting it adds indirection without DRY win). Those can ship as follow-ups if/when reuse comes up.

`FeaturedAction` is re-exported as a type alias of `ProjectAction` so call sites in Projects.tsx + stories keep their existing imports.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm test` 129/129 pass (3 consecutive runs, stable)
- [x] `npx vitest run --project storybook` 110/110 pass
- [x] `npm run build` clean (main bundle/CSS sizes unchanged within noise)
- [x] Puppeteer smoke (10 checks) 10/10 pass against the prod preview
- [ ] Visual diff via Storybook/Chromatic — recommended before merge
