### PR TITLE
refactor(#106): extract 4 more primitives — SliderArrowButton, HeroChatCta, ResumeButton, NavLink

### DIFF
--- a/src/components/FeaturedImageSlider.tsx
+++ b/src/components/FeaturedImageSlider.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import SliderArrowButton from './SliderArrowButton';
 import '../assets/styles/FeaturedImageSlider.css';
 
 export type FeaturedImageSlide = {
@@ -211,28 +212,16 @@ const FeaturedImageSlider = ({
 
             {useArrows && images.length > 1 && (
                 <>
-                    <button
-                        type="button"
-                        aria-label="Previous image"
-                        className="featured-image-slider__arrow featured-image-slider__arrow--prev"
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            prev();
-                        }}
-                    >
-                        <span aria-hidden>‹</span>
-                    </button>
-                    <button
-                        type="button"
-                        aria-label="Next image"
-                        className="featured-image-slider__arrow featured-image-slider__arrow--next"
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            next();
-                        }}
-                    >
-                        <span aria-hidden>›</span>
-                    </button>
+                    <SliderArrowButton
+                        direction="prev"
+                        classScope="featured-image-slider__arrow"
+                        onClick={prev}
+                    />
+                    <SliderArrowButton
+                        direction="next"
+                        classScope="featured-image-slider__arrow"
+                        onClick={next}
+                    />
                 </>
             )}
 
@@ -308,28 +297,16 @@ const FeaturedImageSlider = ({
                     </button>
                     {images.length > 1 && (
                         <>
-                            <button
-                                type="button"
-                                aria-label="Previous image"
-                                className="featured-image-slider__lightbox-arrow featured-image-slider__lightbox-arrow--prev"
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                    prev();
-                                }}
-                            >
-                                <span aria-hidden>‹</span>
-                            </button>
-                            <button
-                                type="button"
-                                aria-label="Next image"
-                                className="featured-image-slider__lightbox-arrow featured-image-slider__lightbox-arrow--next"
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                    next();
-                                }}
-                            >
-                                <span aria-hidden>›</span>
-                            </button>
+                            <SliderArrowButton
+                                direction="prev"
+                                classScope="featured-image-slider__lightbox-arrow"
+                                onClick={prev}
+                            />
+                            <SliderArrowButton
+                                direction="next"
+                                classScope="featured-image-slider__lightbox-arrow"
+                                onClick={next}
+                            />
                         </>
                     )}
                 </div>,

--- a/src/components/HeroChatCta.tsx
+++ b/src/components/HeroChatCta.tsx
@@ -1,0 +1,20 @@
+import { ArrowRightCircle } from 'react-bootstrap-icons';
+
+type Props = {
+    /** Element id to scroll into view on click. Defaults to "contact". */
+    targetId?: string;
+};
+
+// Hero "Let's Chat" CTA. Plain text + ArrowRightCircle icon. Styling
+// lives in Hero.css under `.hero .hero-contact-button`.
+const HeroChatCta = ({ targetId = 'contact' }: Props) => (
+    <button
+        className="hero-contact-button"
+        onClick={() => document.getElementById(targetId)?.scrollIntoView()}
+    >
+        Let&apos;s Chat
+        <ArrowRightCircle size={25} />
+    </button>
+);
+
+export default HeroChatCta;

--- a/src/components/HeroContent.tsx
+++ b/src/components/HeroContent.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
-import { ArrowRightCircle } from 'react-bootstrap-icons';
 import TaglineBadge from './TaglineBadge';
+import HeroChatCta from './HeroChatCta';
 import { advanceTyping, initialTypingState, type TypingState } from './heroTyping';
 
 const HeroContent = () => {
@@ -80,13 +80,7 @@ const HeroContent = () => {
                 </a>
                 .
             </p>
-            <button
-                className="hero-contact-button"
-                onClick={() => document.getElementById('contact')?.scrollIntoView()}
-            >
-                Let's Chat
-                <ArrowRightCircle size={25} />
-            </button>
+            <HeroChatCta />
         </div>
     );
 };

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -2,8 +2,9 @@ import '../assets/styles/NavBar.css';
 
 import { useState, useEffect } from 'react';
 import { Container, Nav, Navbar } from 'react-bootstrap';
-import { FileEarmarkText } from 'react-bootstrap-icons';
 import SocialIcons from './SocialIcons';
+import NavLink from './NavLink';
+import ResumeButton from './ResumeButton';
 
 import logo from '../assets/images/logo.svg';
 import linkedInIcon from '../assets/images/icons/linked-in.svg';
@@ -110,10 +111,6 @@ const NavBar = () => {
         setBgTransparent(!bgTransparent);
     };
 
-    const handleActiveLink = (link: string) => {
-        if (activeLink === link) return 'active';
-    };
-
     const onLinkClick = (linkName: string) => {
         setActiveLink(linkName);
         setBgTransparent(false);
@@ -143,27 +140,18 @@ const NavBar = () => {
                 <Navbar.Collapse id="basic-navbar-nav">
                     <Nav className="me-auto">
                         {navLinks.map(({ name, text }) => (
-                            <Nav.Link
-                                href={`#${name}`}
+                            <NavLink
                                 key={name}
-                                className={`${handleActiveLink(name)} navbar-link`}
+                                name={name}
+                                text={text}
+                                isActive={activeLink === name}
                                 onClick={() => onLinkClick(name)}
-                            >
-                                {text}
-                            </Nav.Link>
+                            />
                         ))}
                     </Nav>
                     <span className="navbar-text">
                         <SocialIcons config={socialsConfig} />
-                        <button
-                            className="resume-button"
-                            onClick={() =>
-                                window.open(`${import.meta.env.BASE_URL}${resumePath.replace(/^\//, '')}`)
-                            }
-                        >
-                            <FileEarmarkText size={20} className="me-2" />
-                            <span>My Resume</span>
-                        </button>
+                        <ResumeButton resumePath={resumePath} />
                     </span>
                 </Navbar.Collapse>
             </Container>

--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -1,0 +1,24 @@
+import { Nav } from 'react-bootstrap';
+
+type Props = {
+    /** Section id this link points to (also used as the URL hash). */
+    name: string;
+    text: string;
+    isActive: boolean;
+    onClick: () => void;
+};
+
+// Top-level nav link rendered inside NavBar's Nav.Link map. Wraps
+// react-bootstrap's Nav.Link with the active-class logic so the host
+// component doesn't have to build the className string ad-hoc.
+const NavLink = ({ name, text, isActive, onClick }: Props) => (
+    <Nav.Link
+        href={`#${name}`}
+        className={`${isActive ? 'active' : ''} navbar-link`}
+        onClick={onClick}
+    >
+        {text}
+    </Nav.Link>
+);
+
+export default NavLink;

--- a/src/components/ResumeButton.tsx
+++ b/src/components/ResumeButton.tsx
@@ -1,0 +1,22 @@
+import { FileEarmarkText } from 'react-bootstrap-icons';
+
+type Props = {
+    /** Resume URL relative to the site root (e.g. "/resources/resume.pdf"). */
+    resumePath: string;
+};
+
+// "My Resume" button rendered on the right side of the NavBar. Opens the
+// PDF in a new tab. Styling lives in NavBar.css under `.resume-button`.
+const ResumeButton = ({ resumePath }: Props) => (
+    <button
+        className="resume-button"
+        onClick={() =>
+            window.open(`${import.meta.env.BASE_URL}${resumePath.replace(/^\//, '')}`)
+        }
+    >
+        <FileEarmarkText size={20} className="me-2" />
+        <span>My Resume</span>
+    </button>
+);
+
+export default ResumeButton;

--- a/src/components/SliderArrowButton.tsx
+++ b/src/components/SliderArrowButton.tsx
@@ -1,0 +1,39 @@
+type Direction = 'prev' | 'next';
+
+type Props = {
+    direction: Direction;
+    /** CSS class scope. The slider chrome uses `featured-image-slider__arrow`,
+        the lightbox chrome uses `featured-image-slider__lightbox-arrow`. */
+    classScope: 'featured-image-slider__arrow' | 'featured-image-slider__lightbox-arrow';
+    onClick: () => void;
+};
+
+const LABEL: Record<Direction, string> = {
+    prev: 'Previous image',
+    next: 'Next image'
+};
+
+const GLYPH: Record<Direction, string> = {
+    prev: '‹',
+    next: '›'
+};
+
+// Prev/next chevron button used by FeaturedImageSlider in two places:
+// the slider chrome and the open lightbox. Same markup, different CSS
+// class scopes — keep classScope explicit so callers control which
+// chrome the button belongs to.
+const SliderArrowButton = ({ direction, classScope, onClick }: Props) => (
+    <button
+        type="button"
+        aria-label={LABEL[direction]}
+        className={`${classScope} ${classScope}--${direction}`}
+        onClick={(e) => {
+            e.stopPropagation();
+            onClick();
+        }}
+    >
+        <span aria-hidden>{GLYPH[direction]}</span>
+    </button>
+);
+
+export default SliderArrowButton;


### PR DESCRIPTION
## Summary

Continues #106 — second batch of atomic primitive extractions on top of #134.

| Primitive | Used in | DRY win |
|---|---|---|
| `SliderArrowButton` | FeaturedImageSlider (slider chrome + lightbox chrome, 4 inline blocks) | **High** — 4 instances replace 4 inline button blocks |
| `HeroChatCta` | HeroContent | Single-use; isolates the Let's Chat button + scroll handler |
| `ResumeButton` | NavBar | Single-use; isolates the `window.open` + `FileEarmarkText` icon |
| `NavLink` | NavBar (4× via `navLinks.map`) | Encapsulates the active-class logic; removes `handleActiveLink` from NavBar |

### Skipped (intentionally)

`ContactSubmit` and the per-input form fields. The submit button is 3 lines of trivial markup (`<button type="submit"><span>Send</span></button>`); extracting it adds an indirection without saving meaningful code. The form fields share a pattern (5 inputs + 1 textarea) but extraction would need to handle the aria-invalid plumbing + inline `fieldError` rendering — a bigger refactor that's worth its own PR if reuse appears.

`SliderControlsPrimitive`'s **dot indicators** (frosted, outlined, segmented-progress) are tightly coupled to FeaturedImageSlider's state via the `dotIndicator` closure. Promoting them would require exposing a non-trivial API; the current closure is fine.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm test` 129/129 pass
- [x] `npx vitest run --project storybook` 110/110 pass
- [x] `npm run build` clean
- [x] Puppeteer smoke (10 checks) 10/10 pass
