### PR TITLE
fix(stories): add Exotic Car Trader to Projects ClientTab story

### DIFF
--- a/src/components/Projects.stories.tsx
+++ b/src/components/Projects.stories.tsx
@@ -11,6 +11,7 @@ import '../assets/styles/Projects.css';
 import generalProvision from '../assets/images/projects/general-provision-512.png';
 import trimAgency from '../assets/images/projects/trim-agency-512.png';
 import cSolutions from '../assets/images/projects/c-solutions-512.png';
+import exoticCarTrader from '../assets/images/projects/exotic-car-trader-512.png';
 import filthyFood from '../assets/images/projects/filthy-food-512.png';
 import federated from '../assets/images/projects/federated-512.png';
 import voicepoolImg from '../assets/images/projects/voicepool.png';
@@ -85,6 +86,12 @@ const clientProjects = [
         description: 'Web Development',
         imageURL: cSolutions,
         url: '//csolutions-us.com/'
+    },
+    {
+        title: 'Exotic Car Trader',
+        description: 'Web Development',
+        imageURL: exoticCarTrader,
+        url: '//www.exoticcartrader.com/'
     },
     {
         title: 'Federated Insurance',


### PR DESCRIPTION
## Summary

Production `Projects.tsx` `clientProjects` lists **6** entries (TRIM, C Solutions, ECT, Federated, Filthy Food, General Provision). The matching storybook story listed only **5** — Exotic Car Trader was missing.

Adds ECT in the same position as production (between C Solutions and Federated) so `Projects > ClientTab` and `Projects > TabSwitched` render the same 6 cards visitors see on the live site.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npx vitest run --project storybook src/components/Projects.stories.tsx` — 4/4 pass
