### PR TITLE
chore: pin chromatic projectId and enable zip upload

### DIFF
--- a/chromatic.config.json
+++ b/chromatic.config.json
@@ -1,7 +1,9 @@
 {
-    "$schema": "https://www.chromatic.com/config-file.schema.json",
-    "buildScriptName": "build-storybook",
-    "onlyChanged": true,
-    "exitOnceUploaded": true,
-    "skip": "main"
+  "$schema": "https://www.chromatic.com/config-file.schema.json",
+  "buildScriptName": "build-storybook",
+  "exitOnceUploaded": true,
+  "onlyChanged": true,
+  "projectId": "Project:69f55ceb61630e3b7231f2d0",
+  "skip": "main",
+  "zip": true
 }


### PR DESCRIPTION
## Summary
- Persists Chromatic `projectId` in `chromatic.config.json` (eliminates env-var dependency for local runs)
- Enables `zip: true` for faster Chromatic uploads

Auto-injected by Chromatic CLI on a recent local run. Pre-cleared as a drive-by config pin before starting the codebase audit roadmap (Phase 0 lands next on its own branch).

## Test plan
- [x] `npm run build-storybook` still succeeds (no schema changes, just additive fields)
- [x] No source code touched