### PR TITLE
refactor: Phase 1 — foundation hooks and data extraction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "react-bootstrap": "^2.5.0",
         "react-bootstrap-icons": "^1.9.1",
         "react-dom": "^18.2.0",
-        "react-intersection-observer": "^10.0.3",
         "react-multi-carousel": "^2.8.2"
       },
       "devDependencies": {
@@ -12313,21 +12312,6 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
-      }
-    },
-    "node_modules/react-intersection-observer": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-10.0.3.tgz",
-      "integrity": "sha512-luICLMbs0zxTO/70Zy7K5jOXkABPEVSAF8T3FdZUlctsrIaPLmx8TZe2SSA+CY2HGWfz2INyNTnp82pxNNsShA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "react-bootstrap": "^2.5.0",
     "react-bootstrap-icons": "^1.9.1",
     "react-dom": "^18.2.0",
-    "react-intersection-observer": "^10.0.3",
-    "react-multi-carousel": "^2.8.2"
+"react-multi-carousel": "^2.8.2"
   },
   "scripts": {
     "dev": "vite",

--- a/src/components/ContactMe.tsx
+++ b/src/components/ContactMe.tsx
@@ -2,6 +2,7 @@ import "../assets/styles/Contact.css";
 import { Col, Container, Row } from "react-bootstrap";
 import ContactForm from "./ContactForm";
 import useInViewOnce from "../hooks/useInViewOnce";
+import ResponsiveImage from "./ResponsiveImage";
 
 import contactImage from "../assets/images/bitmoji/bitmoji-laptop-2.png";
 import contactImageWebp from "../assets/images/bitmoji/bitmoji-laptop-2.webp";
@@ -21,13 +22,11 @@ const ContactMe = () => {
                             }`}
                         >
                             <h2 className="hire-me nowrap">Wanna Hire Me?</h2>
-                            <picture>
-                                <source srcSet={contactImageWebp} type="image/webp" />
-                                <img
-                                    src={contactImage}
-                                    alt="Caricature of Miguel working at a laptop"
-                                />
-                            </picture>
+                            <ResponsiveImage
+                                src={contactImage}
+                                srcWebp={contactImageWebp}
+                                alt="Caricature of Miguel working at a laptop"
+                            />
                         </div>
                     </Col>
                     <Col md={6} className="contact-form-container">

--- a/src/components/ContactMe.tsx
+++ b/src/components/ContactMe.tsx
@@ -3,6 +3,7 @@ import { Col, Container, Row } from "react-bootstrap";
 import ContactForm from "./ContactForm";
 import useInViewOnce from "../hooks/useInViewOnce";
 import ResponsiveImage from "./ResponsiveImage";
+import { FADE_IN } from "../constants/animationClasses";
 
 import contactImage from "../assets/images/bitmoji/bitmoji-laptop-2.png";
 import contactImageWebp from "../assets/images/bitmoji/bitmoji-laptop-2.webp";
@@ -18,7 +19,7 @@ const ContactMe = () => {
                         <div
                             ref={ref}
                             className={`content animate__opacity-0 ${
-                                inView && "animate__animated animate__fadeIn"
+                                inView && FADE_IN
                             }`}
                         >
                             <h2 className="hire-me nowrap">Wanna Hire Me?</h2>

--- a/src/components/ContactMe.tsx
+++ b/src/components/ContactMe.tsx
@@ -1,13 +1,13 @@
 import "../assets/styles/Contact.css";
 import { Col, Container, Row } from "react-bootstrap";
-import { useInView } from "react-intersection-observer";
 import ContactForm from "./ContactForm";
+import useInViewOnce from "../hooks/useInViewOnce";
 
 import contactImage from "../assets/images/bitmoji/bitmoji-laptop-2.png";
 import contactImageWebp from "../assets/images/bitmoji/bitmoji-laptop-2.webp";
 
 const ContactMe = () => {
-    const { ref, inView } = useInView({ triggerOnce: true });
+    const { ref, inView } = useInViewOnce<HTMLDivElement>();
 
     return (
         <section id="contact" className="contact">

--- a/src/components/FeaturedImageSlider.tsx
+++ b/src/components/FeaturedImageSlider.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import SliderArrowButton from './SliderArrowButton';
+import ResponsiveImage from './ResponsiveImage';
 import '../assets/styles/FeaturedImageSlider.css';
 
 export type FeaturedImageSlide = {
@@ -194,20 +195,19 @@ const FeaturedImageSlider = ({
             onPointerUp={handlePointerUp}
         >
             {images.map((img, i) => (
-                <picture key={img.src}>
-                    {img.srcWebp && <source srcSet={img.srcWebp} type="image/webp" />}
-                    <img
-                        src={img.src}
-                        alt={img.alt}
-                        loading="lazy"
-                        className={`featured-image-slider__slide ${
-                            i === index ? 'is-active' : ''
-                        } is-clickable`}
-                        aria-hidden={i !== index}
-                        onClick={i === index ? handleSlideClick : undefined}
-                        style={{ objectPosition: imagePosition }}
-                    />
-                </picture>
+                <ResponsiveImage
+                    key={img.src}
+                    src={img.src}
+                    srcWebp={img.srcWebp}
+                    alt={img.alt}
+                    loading="lazy"
+                    className={`featured-image-slider__slide ${
+                        i === index ? 'is-active' : ''
+                    } is-clickable`}
+                    aria-hidden={i !== index}
+                    onClick={i === index ? handleSlideClick : undefined}
+                    style={{ objectPosition: imagePosition }}
+                />
             ))}
 
             {useArrows && images.length > 1 && (
@@ -273,17 +273,13 @@ const FeaturedImageSlider = ({
                     aria-label={images[index].alt}
                     onClick={() => setLightboxOpen(false)}
                 >
-                    <picture>
-                        {images[index].srcWebp && (
-                            <source srcSet={images[index].srcWebp} type="image/webp" />
-                        )}
-                        <img
-                            src={images[index].src}
-                            alt={images[index].alt}
-                            className="featured-image-slider__lightbox-img"
-                            onClick={(e) => e.stopPropagation()}
-                        />
-                    </picture>
+                    <ResponsiveImage
+                        src={images[index].src}
+                        srcWebp={images[index].srcWebp}
+                        alt={images[index].alt}
+                        className="featured-image-slider__lightbox-img"
+                        onClick={(e) => e.stopPropagation()}
+                    />
                     <button
                         type="button"
                         aria-label="Close"

--- a/src/components/FeaturedProjectCard.tsx
+++ b/src/components/FeaturedProjectCard.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from "react";
 import { Col } from "react-bootstrap";
 import TechStackList from "./TechStackList";
 import ProjectActionLink, { type ProjectAction } from "./ProjectActionLink";
+import ResponsiveImage from "./ResponsiveImage";
 
 export type FeaturedAction = ProjectAction;
 
@@ -38,12 +39,12 @@ const FeaturedProjectCard = (props: FeaturedProject) => {
                 <div className="featured-project-image">
                     {props.imageSlot ?? (
                         props.imageURL && (
-                            <picture>
-                                {props.imageURLWebp && (
-                                    <source srcSet={props.imageURLWebp} type="image/webp" />
-                                )}
-                                <img src={props.imageURL} alt={props.title} loading="lazy" />
-                            </picture>
+                            <ResponsiveImage
+                                src={props.imageURL}
+                                srcWebp={props.imageURLWebp}
+                                alt={props.title}
+                                loading="lazy"
+                            />
                         )
                     )}
                 </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,44 +5,7 @@ import PreFooter from "./PreFooter";
 import SocialIcons from "./SocialIcons";
 
 import logo from "../assets/images/logo.svg";
-import codepenIcon from "../assets/images/icons/codepen-icon.svg";
-import npmIcon from "devicon/icons/npm/npm-original-wordmark.svg";
-import codewarsIcon from "../assets/images/icons/codewars-icon.svg";
-import codecademyIcon from "../assets/images/icons/codecademy-icon.svg";
-import duolingoIcon from "../assets/images/icons/duolingo-icon.svg";
-
-const socialsConfig = [
-    {
-        className: "codepen",
-        icon: codepenIcon,
-        url: "//codepen.io/MiguelDotL",
-        label: "CodePen"
-    },
-    {
-        className: "npm",
-        icon: npmIcon,
-        url: "//www.npmjs.com/~migueldotl",
-        label: "npm"
-    },
-    {
-        className: "codewars",
-        icon: codewarsIcon,
-        url: "//www.codewars.com/users/MiguelDotL",
-        label: "Codewars"
-    },
-    {
-        className: "codecademy",
-        icon: codecademyIcon,
-        url: "//www.codecademy.com/profiles/MiguelDotL",
-        label: "Codecademy"
-    },
-    {
-        className: "duolingo",
-        icon: duolingoIcon,
-        url: "//www.duolingo.com/profile/MiguelDotL",
-        label: "Duolingo"
-    }
-];
+import { FOOTER_SOCIALS } from "../data/socials";
 
 const Footer = () => {
     const [hoveredLabel, setHoveredLabel] = useState<string | null>(null);
@@ -62,7 +25,7 @@ const Footer = () => {
                                     <span className="hovered-label">{hoveredLabel}</span>
                                 </span>
                                 <SocialIcons
-                                    config={socialsConfig}
+                                    config={FOOTER_SOCIALS}
                                     onHover={setHoveredLabel}
                                 />
                             </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,6 +1,7 @@
 import "../assets/styles/Hero.css";
 import { Col, Container, Row } from "react-bootstrap";
 import HeroContent from "./HeroContent";
+import ResponsiveImage from "./ResponsiveImage";
 import bitmojiSpacePlanet from "../assets/images/bitmoji/bitmoji-space-planet-2.png";
 import bitmojiSpacePlanetWebp from "../assets/images/bitmoji/bitmoji-space-planet-2.webp";
 
@@ -13,17 +14,15 @@ const Hero = () => {
                         <HeroContent />
                     </Col>
                     <Col className="image-col" xs={12} md={5} xl={5}>
-                        <picture>
-                            <source srcSet={bitmojiSpacePlanetWebp} type="image/webp" />
-                            <img
-                                className="floating-image"
-                                src={bitmojiSpacePlanet}
-                                alt="Floating Caricature"
-                                width={1592}
-                                height={1592}
-                                {...{ fetchpriority: "high" }}
-                            />
-                        </picture>
+                        <ResponsiveImage
+                            className="floating-image"
+                            src={bitmojiSpacePlanet}
+                            srcWebp={bitmojiSpacePlanetWebp}
+                            alt="Floating Caricature"
+                            width={1592}
+                            height={1592}
+                            {...{ fetchpriority: "high" }}
+                        />
                     </Col>
                 </Row>
             </Container>

--- a/src/components/HeroContent.tsx
+++ b/src/components/HeroContent.tsx
@@ -1,37 +1,16 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import TaglineBadge from './TaglineBadge';
 import HeroChatCta from './HeroChatCta';
 import { advanceTyping, initialTypingState, type TypingState } from './heroTyping';
 import { LINKEDIN_URL, DUOLINGO_URL } from '../data/site';
+import useInViewOnce from '../hooks/useInViewOnce';
 
 const HeroContent = () => {
-    const ref = useRef<HTMLDivElement | null>(null);
-    const [inView, setInView] = useState(false);
+    const { ref, inView } = useInViewOnce<HTMLDivElement>();
     const [typing, setTyping] = useState<TypingState>(() =>
         initialTypingState(200 - Math.random() * 50)
     );
     const yearsOfExp = new Date().getFullYear() - 2016;
-
-    // Native IntersectionObserver replaces react-intersection-observer to keep
-    // the lib out of the main bundle (Skills/Projects/ContactMe lazy chunks
-    // still use it). triggerOnce: disconnect after first hit.
-    useEffect(() => {
-        const el = ref.current;
-        if (!el) return;
-        if (typeof IntersectionObserver === 'undefined') {
-            // eslint-disable-next-line react-hooks/set-state-in-effect
-            setInView(true);
-            return;
-        }
-        const io = new IntersectionObserver(([entry]) => {
-            if (entry.isIntersecting) {
-                setInView(true);
-                io.disconnect();
-            }
-        });
-        io.observe(el);
-        return () => io.disconnect();
-    }, []);
 
     // Drive the typing state machine on a setTimeout cadence — each tick
     // schedules the next based on the new state's typingDelay. Self-

--- a/src/components/HeroContent.tsx
+++ b/src/components/HeroContent.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import TaglineBadge from './TaglineBadge';
 import HeroChatCta from './HeroChatCta';
 import { advanceTyping, initialTypingState, type TypingState } from './heroTyping';
+import { LINKEDIN_URL, DUOLINGO_URL } from '../data/site';
 
 const HeroContent = () => {
     const ref = useRef<HTMLDivElement | null>(null);
@@ -59,7 +60,7 @@ const HeroContent = () => {
                 My journey into programming began in 2005. I now have over{' '}
                 <a
                     className="accent nowrap"
-                    href="https://www.linkedin.com/in/migueldot/"
+                    href={LINKEDIN_URL}
                     rel="noreferrer"
                     target="_blank"
                 >
@@ -72,7 +73,7 @@ const HeroContent = () => {
                 learning{' '}
                 <a
                     className="accent nowrap"
-                    href="//www.duolingo.com/profile/MiguelDotL"
+                    href={DUOLINGO_URL}
                     rel="noreferrer"
                     target="_blank"
                 >

--- a/src/components/HeroContent.tsx
+++ b/src/components/HeroContent.tsx
@@ -4,6 +4,7 @@ import HeroChatCta from './HeroChatCta';
 import { advanceTyping, initialTypingState, type TypingState } from './heroTyping';
 import { LINKEDIN_URL, DUOLINGO_URL } from '../data/site';
 import useInViewOnce from '../hooks/useInViewOnce';
+import { FADE_IN_SLOWER } from '../constants/animationClasses';
 
 const HeroContent = () => {
     const { ref, inView } = useInViewOnce<HTMLDivElement>();
@@ -27,7 +28,7 @@ const HeroContent = () => {
         <div
             ref={ref}
             className={`content ${
-                inView && 'animate__animated animate__fadeIn animate__slower'
+                inView && FADE_IN_SLOWER
             }`}
         >
             <TaglineBadge>Thanks for dropping by</TaglineBadge>

--- a/src/components/HoverZoomPan.tsx
+++ b/src/components/HoverZoomPan.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState, type MouseEvent } from 'react';
+import ResponsiveImage from './ResponsiveImage';
 
 type Props = {
     src: string;
@@ -59,10 +60,14 @@ const HoverZoomPan = ({
             onMouseLeave={handleMouseLeave}
             onMouseMove={handleMouseMove}
         >
-            <picture>
-                {srcWebp && <source srcSet={srcWebp} type="image/webp" />}
-                <img ref={imgRef} src={src} alt={alt} loading="lazy" style={imgStyle} />
-            </picture>
+            <ResponsiveImage
+                ref={imgRef}
+                src={src}
+                srcWebp={srcWebp}
+                alt={alt}
+                loading="lazy"
+                style={imgStyle}
+            />
         </div>
     );
 };

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -7,46 +7,14 @@ import NavLink from './NavLink';
 import ResumeButton from './ResumeButton';
 
 import logo from '../assets/images/logo.svg';
-import linkedInIcon from '../assets/images/icons/linked-in.svg';
-import twitterXIcon from '../assets/images/icons/twitter-x.svg';
-import githubIcon from '../assets/images/icons/github-2.svg';
-
-const navLinks = [
-    { name: 'home', text: 'Home' },
-    { name: 'skills', text: 'Skills' },
-    { name: 'projects', text: 'Projects' },
-    { name: 'contact', text: 'Contact' }
-];
+import { NAV_LINKS, RESUME_PATH } from '../data/site';
+import { NAV_SOCIALS } from '../data/socials';
 
 const NavBar = () => {
     const [expanded, setExpanded] = useState(false);
     const [activeLink, setActiveLink] = useState('home');
     const [hasScrolled, setHasScrolled] = useState(false);
     const [bgTransparent, setBgTransparent] = useState(false);
-
-    const socialsConfig = [
-        {
-            className: 'linked-in',
-            icon: linkedInIcon,
-            url: 'https://www.linkedin.com/in/migueldot/',
-            label: 'LinkedIn'
-        },
-        {
-            className: 'twitter',
-            icon: twitterXIcon,
-            // icon: twitterIcon,
-            url: '//twitter.com/MiguelDotL',
-            label: 'X (Twitter)'
-        },
-        {
-            className: 'github',
-            icon: githubIcon,
-            url: '//github.com/MiguelDotL',
-            label: 'GitHub'
-        }
-    ];
-
-    const resumePath = '/resources/miguel_lozano_resume_2024.pdf';
 
     useEffect(() => {
         const onScroll = () => {
@@ -65,7 +33,7 @@ const NavBar = () => {
     // Monotonic — won't oscillate as sections enter/exit the viewport.
     // Listener attaches via requestIdleCallback so it doesn't compete with LCP.
     useEffect(() => {
-        const sectionIds = navLinks.map(({ name }) => name);
+        const sectionIds = NAV_LINKS.map(({ name }) => name);
 
         const onScroll = () => {
             const triggerY = 100;
@@ -73,7 +41,7 @@ const NavBar = () => {
                 .map((id) => document.getElementById(id))
                 .filter((el): el is HTMLElement => el !== null);
 
-            let current = sectionIds[0];
+            let current: string = sectionIds[0];
             for (const section of sections) {
                 if (section.getBoundingClientRect().top <= triggerY) {
                     current = section.id;
@@ -139,7 +107,7 @@ const NavBar = () => {
 
                 <Navbar.Collapse id="basic-navbar-nav">
                     <Nav className="me-auto">
-                        {navLinks.map(({ name, text }) => (
+                        {NAV_LINKS.map(({ name, text }) => (
                             <NavLink
                                 key={name}
                                 name={name}
@@ -150,8 +118,8 @@ const NavBar = () => {
                         ))}
                     </Nav>
                     <span className="navbar-text">
-                        <SocialIcons config={socialsConfig} />
-                        <ResumeButton resumePath={resumePath} />
+                        <SocialIcons config={NAV_SOCIALS} />
+                        <ResumeButton resumePath={RESUME_PATH} />
                     </span>
                 </Navbar.Collapse>
             </Container>

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,4 +1,5 @@
 import { Col } from "react-bootstrap";
+import ResponsiveImage from "./ResponsiveImage";
 
 export type Project = {
     title: string;
@@ -16,12 +17,12 @@ const ProjectCard = (props: Project) => {
         <Col sm={6} md={4}>
             <div className="project-card">
                 <div className="project-image">
-                    <picture>
-                        {props.imageURLWebp && (
-                            <source srcSet={props.imageURLWebp} type="image/webp" />
-                        )}
-                        <img src={props.imageURL} alt={props.title} loading="lazy" />
-                    </picture>
+                    <ResponsiveImage
+                        src={props.imageURL}
+                        srcWebp={props.imageURLWebp}
+                        alt={props.title}
+                        loading="lazy"
+                    />
                     <div className="project-content">
                         <h3>{props.title}</h3>
                         <span>{props.description}</span>

--- a/src/components/Projects.stories.tsx
+++ b/src/components/Projects.stories.tsx
@@ -8,16 +8,13 @@ import FeaturedImageSlider from './FeaturedImageSlider';
 import ProjectList from './ProjectList';
 import '../assets/styles/Projects.css';
 
-import generalProvision from '../assets/images/projects/general-provision-512.png';
-import trimAgency from '../assets/images/projects/trim-agency-512.png';
-import cSolutions from '../assets/images/projects/c-solutions-512.png';
-import exoticCarTrader from '../assets/images/projects/exotic-car-trader-512.png';
-import filthyFood from '../assets/images/projects/filthy-food-512.png';
-import federated from '../assets/images/projects/federated-512.png';
-import voicepoolImg from '../assets/images/projects/voicepool.png';
-import patternArchiveDashboard from '../assets/images/projects/pattern-archive-dashboard.png';
-import patternArchiveWizard from '../assets/images/projects/pattern-archive-wizard-editor.png';
-import patternArchiveLibrary from '../assets/images/projects/pattern-archive-library.png';
+import {
+    CLIENT_PROJECTS,
+    voicepoolImg,
+    patternArchiveDashboard,
+    patternArchiveWizard,
+    patternArchiveLibrary
+} from '../data/projects';
 
 const meta: Meta<typeof Projects> = {
     title: 'Showcase/Sections/Projects',
@@ -74,48 +71,9 @@ const tabSectionDecorator = (children: ReactNode) => (
     </section>
 );
 
-const clientProjects = [
-    {
-        title: 'T R I M Agency',
-        description: 'Web Development',
-        imageURL: trimAgency,
-        url: '//www.trimagency.com/'
-    },
-    {
-        title: 'C Solutions',
-        description: 'Web Development',
-        imageURL: cSolutions,
-        url: '//csolutions-us.com/'
-    },
-    {
-        title: 'Exotic Car Trader',
-        description: 'Web Development',
-        imageURL: exoticCarTrader,
-        url: '//www.exoticcartrader.com/'
-    },
-    {
-        title: 'Federated Insurance',
-        description: 'Web Development',
-        imageURL: federated,
-        url: '//www.federated.ca/'
-    },
-    {
-        title: 'Filthy Food',
-        description: 'Ecommerce',
-        imageURL: filthyFood,
-        url: '//filthyfood.com/'
-    },
-    {
-        title: 'General Provision',
-        description: 'Web Development',
-        imageURL: generalProvision,
-        url: '//generalprovision.com/'
-    }
-];
-
 export const ClientTab = {
     render: () =>
-        tabSectionDecorator(<ProjectList projects={clientProjects} />)
+        tabSectionDecorator(<ProjectList projects={CLIENT_PROJECTS} />)
 };
 
 export const PersonalTab = {

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -34,6 +34,7 @@ import {
 
 import colorPop from '../assets/images/backgrounds/color-pop-2.png';
 import colorPopWebp from '../assets/images/backgrounds/color-pop-2.webp';
+import ResponsiveImage from './ResponsiveImage';
 
 const TABS = ['Client', 'Featured', 'Personal'] as const;
 type Tab = (typeof TABS)[number];
@@ -112,18 +113,16 @@ const Projects = ({ initialInView = false }: ProjectsProps = {}) => {
 
     return (
         <section id="projects" className="projects">
-            <picture>
-                <source srcSet={colorPopWebp} type="image/webp" />
-                <img
-                    src={colorPop}
-                    alt=""
-                    aria-hidden="true"
-                    className="background-image-right"
-                    width={667}
-                    height={1064}
-                    loading="lazy"
-                />
-            </picture>
+            <ResponsiveImage
+                src={colorPop}
+                srcWebp={colorPopWebp}
+                alt=""
+                aria-hidden="true"
+                className="background-image-right"
+                width={667}
+                height={1064}
+                loading="lazy"
+            />
             <Container>
                 <Row>
                     <Col>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -35,6 +35,7 @@ import {
 import colorPop from '../assets/images/backgrounds/color-pop-2.png';
 import colorPopWebp from '../assets/images/backgrounds/color-pop-2.webp';
 import ResponsiveImage from './ResponsiveImage';
+import { FADE_IN_SLOWER } from '../constants/animationClasses';
 
 const TABS = ['Client', 'Featured', 'Personal'] as const;
 type Tab = (typeof TABS)[number];
@@ -130,7 +131,7 @@ const Projects = ({ initialInView = false }: ProjectsProps = {}) => {
                             ref={ref}
                             className={`content animate__opacity-0 ${
                                 inView &&
-                                'animate__animated animate__fadeIn animate__slower'
+                                FADE_IN_SLOWER
                             }`}
                         >
                             <h2>Projects</h2>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -12,85 +12,31 @@ import NpmPlainIcon from './NpmPlainIcon';
 
 import { TAB_ANIMATION } from './projectsTabAnimation';
 
-import generalProvision from '../assets/images/projects/general-provision-512.png';
-import generalProvisionWebp from '../assets/images/projects/general-provision-512.webp';
-import trimAgency from '../assets/images/projects/trim-agency-512.png';
-import trimAgencyWebp from '../assets/images/projects/trim-agency-512.webp';
-import cSolutions from '../assets/images/projects/c-solutions-512.png';
-import cSolutionsWebp from '../assets/images/projects/c-solutions-512.webp';
-import filthyFood from '../assets/images/projects/filthy-food-512.png';
-import filthyFoodWebp from '../assets/images/projects/filthy-food-512.webp';
-import federated from '../assets/images/projects/federated-512.png';
-import federatedWebp from '../assets/images/projects/federated-512.webp';
-import exoticCarTrader from '../assets/images/projects/exotic-car-trader-512.png';
-import exoticCarTraderWebp from '../assets/images/projects/exotic-car-trader-512.webp';
-import bcbsMain from '../assets/images/projects/bcbs-main.png';
-import bcbsMainWebp from '../assets/images/projects/bcbs-main.webp';
-import bcbsLitehouse from '../assets/images/projects/bcbs-litehouse.png';
-import bcbsLitehouseWebp from '../assets/images/projects/bcbs-litehouse.webp';
-import bcbsProviders from '../assets/images/projects/bcbs-providers.png';
-import bcbsProvidersWebp from '../assets/images/projects/bcbs-providers.webp';
-import voicepoolImg from '../assets/images/projects/voicepool.png';
-import voicepoolImgWebp from '../assets/images/projects/voicepool.webp';
-import branchBeaconImg from '../assets/images/projects/branch-beacon.png';
-import branchBeaconImgWebp from '../assets/images/projects/branch-beacon.webp';
-import patternArchiveDashboard from '../assets/images/projects/pattern-archive-dashboard.png';
-import patternArchiveDashboardWebp from '../assets/images/projects/pattern-archive-dashboard.webp';
-import patternArchiveWizard from '../assets/images/projects/pattern-archive-wizard-editor.png';
-import patternArchiveWizardWebp from '../assets/images/projects/pattern-archive-wizard-editor.webp';
-import patternArchiveLibrary from '../assets/images/projects/pattern-archive-library.png';
-import patternArchiveLibraryWebp from '../assets/images/projects/pattern-archive-library.webp';
+import {
+    CLIENT_PROJECTS,
+    bcbsMain,
+    bcbsMainWebp,
+    bcbsLitehouse,
+    bcbsLitehouseWebp,
+    bcbsProviders,
+    bcbsProvidersWebp,
+    voicepoolImg,
+    voicepoolImgWebp,
+    branchBeaconImg,
+    branchBeaconImgWebp,
+    patternArchiveDashboard,
+    patternArchiveDashboardWebp,
+    patternArchiveWizard,
+    patternArchiveWizardWebp,
+    patternArchiveLibrary,
+    patternArchiveLibraryWebp
+} from '../data/projects';
 
 import colorPop from '../assets/images/backgrounds/color-pop-2.png';
 import colorPopWebp from '../assets/images/backgrounds/color-pop-2.webp';
 
 const TABS = ['Client', 'Featured', 'Personal'] as const;
 type Tab = (typeof TABS)[number];
-
-const clientProjects = [
-    {
-        title: 'T R I M Agency',
-        description: 'Web Development',
-        imageURL: trimAgency,
-        imageURLWebp: trimAgencyWebp,
-        url: '//www.trimagency.com/'
-    },
-    {
-        title: 'C Solutions',
-        description: 'Web Development',
-        imageURL: cSolutions,
-        imageURLWebp: cSolutionsWebp,
-        url: '//csolutions-us.com/'
-    },
-    {
-        title: 'Exotic Car Trader',
-        description: 'Web Development',
-        imageURL: exoticCarTrader,
-        imageURLWebp: exoticCarTraderWebp,
-        url: '//www.exoticcartrader.com/'
-    },
-    {
-        title: 'Federated Insurance',
-        description: 'Web Development',
-        imageURL: federated,
-        imageURLWebp: federatedWebp,
-        url: '//www.federated.ca/'
-    },
-    {
-        title: 'Filthy Food',
-        description: 'Ecommerce',
-        imageURL: filthyFood,
-        imageURLWebp: filthyFoodWebp,
-        url: '//filthyfood.com/'
-    },
-    {
-        title: 'General Provision',
-        description: 'Web Development',
-        imageURL: generalProvision,
-        imageURLWebp: generalProvisionWebp,
-        url: '//generalprovision.com/'
-    }
-];
 
 const TAB_FADE_MS = TAB_ANIMATION.fadeMs;
 
@@ -358,7 +304,7 @@ const Projects = ({ initialInView = false }: ProjectsProps = {}) => {
                                         </Row>
                                     )}
                                     {displayedTab === 'Client' && (
-                                        <ProjectList projects={clientProjects} />
+                                        <ProjectList projects={CLIENT_PROJECTS} />
                                     )}
                                     {displayedTab === 'Personal' && (
                                         <Row>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,8 +1,8 @@
 import '../assets/styles/Projects.css';
 import { useEffect, useRef, useState } from 'react';
 import { Col, Container, Row } from 'react-bootstrap';
-import { useInView } from 'react-intersection-observer';
 import { Globe } from 'react-bootstrap-icons';
+import useInViewOnce from '../hooks/useInViewOnce';
 import ProjectList from './ProjectList';
 import MomentumTabs from './MomentumTabs';
 import FeaturedProjectCard from './FeaturedProjectCard';
@@ -49,7 +49,12 @@ type ProjectsProps = {
 };
 
 const Projects = ({ initialInView = false }: ProjectsProps = {}) => {
-    const { ref, inView } = useInView({ triggerOnce: true, initialInView });
+    const { ref: ioRef, inView: ioInView } = useInViewOnce<HTMLDivElement>();
+    // initialInView is a Storybook escape hatch — when true, skip the IO
+    // and treat the section as already visible so MomentumTabs draws its
+    // perimeter immediately in the canvas iframe.
+    const inView = initialInView || ioInView;
+    const ref = initialInView ? undefined : ioRef;
     const [activeTab, setActiveTab] = useState<Tab>('Featured');
     // Tab content slides + fades out → swap → slides + fades in. `displayedTab`
     // lags `activeTab` during the exit window so the old content stays visible

--- a/src/components/ResponsiveImage.tsx
+++ b/src/components/ResponsiveImage.tsx
@@ -1,0 +1,34 @@
+import { forwardRef } from 'react';
+import type { ImgHTMLAttributes } from 'react';
+
+type ResponsiveImageProps = ImgHTMLAttributes<HTMLImageElement> & {
+    src: string;
+    /** Optional WebP source. When provided, a <picture> wrapper is rendered
+        so browsers that support WebP use the smaller file; `src` (PNG/JPG)
+        stays as the universal fallback. When absent, renders a bare <img>. */
+    srcWebp?: string;
+    alt: string;
+};
+
+/**
+ * Renders `<picture><source type="image/webp" /><img /></picture>` when
+ * `srcWebp` is supplied, or a plain `<img>` when it is not. All extra props
+ * are forwarded to the `<img>` element.
+ */
+const ResponsiveImage = forwardRef<HTMLImageElement, ResponsiveImageProps>(
+    ({ src, srcWebp, alt, ...rest }, ref) => {
+        if (srcWebp) {
+            return (
+                <picture>
+                    <source srcSet={srcWebp} type="image/webp" />
+                    <img ref={ref} src={src} alt={alt} {...rest} />
+                </picture>
+            );
+        }
+        return <img ref={ref} src={src} alt={alt} {...rest} />;
+    }
+);
+
+ResponsiveImage.displayName = 'ResponsiveImage';
+
+export default ResponsiveImage;

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -5,24 +5,23 @@ import colorPop from "../assets/images/backgrounds/color-pop.png";
 import colorPopWebp from "../assets/images/backgrounds/color-pop.webp";
 import SkillsCarousel from "./SkillsCarousel";
 import useInViewOnce from "../hooks/useInViewOnce";
+import ResponsiveImage from "./ResponsiveImage";
 
 const Skills = () => {
     const { ref, inView } = useInViewOnce<HTMLDivElement>();
 
     return (
         <section id="skills" className="skills">
-            <picture>
-                <source srcSet={colorPopWebp} type="image/webp" />
-                <img
-                    src={colorPop}
-                    alt=""
-                    aria-hidden="true"
-                    className="background-image-left"
-                    width={776}
-                    height={1064}
-                    loading="lazy"
-                />
-            </picture>
+            <ResponsiveImage
+                src={colorPop}
+                srcWebp={colorPopWebp}
+                alt=""
+                aria-hidden="true"
+                className="background-image-left"
+                width={776}
+                height={1064}
+                loading="lazy"
+            />
             <Container>
                 <Row>
                     <div className="skills-content">

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -1,13 +1,13 @@
 import "../assets/styles/Skills.css";
 import { Container, Row } from "react-bootstrap";
-import { useInView } from "react-intersection-observer";
 import "react-multi-carousel/lib/styles.css";
 import colorPop from "../assets/images/backgrounds/color-pop.png";
 import colorPopWebp from "../assets/images/backgrounds/color-pop.webp";
 import SkillsCarousel from "./SkillsCarousel";
+import useInViewOnce from "../hooks/useInViewOnce";
 
 const Skills = () => {
-    const { ref, inView } = useInView({ triggerOnce: true });
+    const { ref, inView } = useInViewOnce<HTMLDivElement>();
 
     return (
         <section id="skills" className="skills">

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -6,6 +6,7 @@ import colorPopWebp from "../assets/images/backgrounds/color-pop.webp";
 import SkillsCarousel from "./SkillsCarousel";
 import useInViewOnce from "../hooks/useInViewOnce";
 import ResponsiveImage from "./ResponsiveImage";
+import { FADE_IN_SLOWER } from "../constants/animationClasses";
 
 const Skills = () => {
     const { ref, inView } = useInViewOnce<HTMLDivElement>();
@@ -29,7 +30,7 @@ const Skills = () => {
                             ref={ref}
                             className={`animate__opacity-0 ${
                                 inView &&
-                                "animate__animated animate__fadeIn animate__slower"
+                                FADE_IN_SLOWER
                             }`}
                         >
                             <h2>Skills</h2>

--- a/src/components/SkillsCarousel.tsx
+++ b/src/components/SkillsCarousel.tsx
@@ -1,23 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import CarouselDefault from "react-multi-carousel";
 const Carousel = (CarouselDefault as { default?: typeof CarouselDefault }).default || CarouselDefault;
-import claudeIcon from "../assets/images/icons/claude.svg";
-import pythonIcon from "../assets/images/icons/python.svg";
-import fastapiIcon from "../assets/images/icons/fastapi.svg";
-import html5Icon from "../assets/images/icons/html5.svg";
-import css3Icon from "../assets/images/icons/css3.svg";
-import mysqlIcon from "../assets/images/icons/mysql.svg";
-import postgresqlIcon from "../assets/images/icons/postgresql.svg";
-import mongodbIcon from "../assets/images/icons/mongodb.svg";
-import linuxIcon from "../assets/images/icons/linux.svg";
-
-type Skill = {
-    name: string;
-    class?: string;
-    color?: string;
-    iconPath?: string;
-    iconInactive?: string;
-};
+import { SKILLS } from "../data/skills";
 
 type CarouselState = {
     currentSlide: number;
@@ -94,31 +78,6 @@ const SkillsCarousel = () => {
         }
     };
 
-    const skills: Skill[] = [
-        { name: "Bash", class: "bash-plain", color: "#44B04F" },
-        { name: "HTML", class: "html5-plain", iconPath: html5Icon },
-        { name: "CSS", class: "css3-plain", iconPath: css3Icon },
-        { name: "JavaScript", class: "javascript-plain" },
-        { name: "TypeScript", class: "typescript-plain" },
-        { name: "jQuery", class: "jquery-plain" },
-        { name: "React", class: "react-original" },
-        { name: "Angular", class: "angularjs-plain" },
-        { name: "Node.js", class: "nodejs-plain" },
-        { name: "mongoDB", class: "mongodb-plain", iconPath: mongodbIcon },
-        { name: "PHP", class: "php-plain" },
-        { name: "MySQL", iconPath: mysqlIcon },
-        { name: "Ruby", class: "ruby-plain", color: "#940c00" },
-        { name: "Ruby on Rails", class: "rails-plain", color: "#940c00" },
-        { name: "Python", iconPath: pythonIcon },
-        { name: "FastAPI", iconPath: fastapiIcon },
-        { name: "PostgreSQL", class: "postgresql-plain", iconPath: postgresqlIcon },
-        { name: "AWS", class: "amazonwebservices-original" },
-        { name: "Linux", class: "linux-plain", color: "#EBC205", iconPath: linuxIcon },
-        { name: "GitHub", class: "github-original", color: "#9355AD" },
-        { name: "Git", class: "git-plain" },
-        { name: "Claude", iconPath: claudeIcon, color: "#D97757" }
-    ];
-
     // Fires when a slide transition begins — we update centeredIndex here
     // (rather than only in afterChange) so the white BG fade starts as soon
     // as movement starts, not after the carousel lands.
@@ -185,7 +144,7 @@ const SkillsCarousel = () => {
             beforeChange={handleBeforeChange}
             afterChange={handleAfterChange}
         >
-            {skills.map((skill) => {
+            {SKILLS.map((skill) => {
                 const inactiveTag = skill.iconInactive || skill.class;
                 const isCrossFade = inactiveTag && skill.iconPath;
                 return (

--- a/src/constants/animationClasses.ts
+++ b/src/constants/animationClasses.ts
@@ -1,0 +1,9 @@
+/**
+ * Animation class constants. These match custom @keyframes rules defined in
+ * src/index.css (~lines 165-300) — animate.css is NOT installed as a
+ * dependency. Do not add animate.css; these strings are the canonical source.
+ */
+
+export const FADE_IN = 'animate__animated animate__fadeIn';
+
+export const FADE_IN_SLOWER = 'animate__animated animate__fadeIn animate__slower';

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,141 @@
+import type { ReactNode } from 'react';
+import type { ProjectAction } from '../components/ProjectActionLink';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type Project = {
+    title: string;
+    description: string;
+    imageURL: string;
+    /** Optional WebP source. When provided, browsers that support WebP
+        get the smaller file via <picture>; PNG stays as the universal
+        fallback. */
+    imageURLWebp?: string;
+    url: string;
+};
+
+export type FeaturedProject = {
+    title: string;
+    subtitle?: string;
+    description: ReactNode;
+    techStack?: string[];
+    imageURL?: string;
+    /** Optional WebP source for the imageURL fallback path. */
+    imageURLWebp?: string;
+    imageSlot?: ReactNode;
+    actions?: ProjectAction[];
+};
+
+// ── Image imports (re-exported for consumers like Projects.tsx) ───────────────
+
+import generalProvision from '../assets/images/projects/general-provision-512.png';
+import generalProvisionWebp from '../assets/images/projects/general-provision-512.webp';
+import trimAgency from '../assets/images/projects/trim-agency-512.png';
+import trimAgencyWebp from '../assets/images/projects/trim-agency-512.webp';
+import cSolutions from '../assets/images/projects/c-solutions-512.png';
+import cSolutionsWebp from '../assets/images/projects/c-solutions-512.webp';
+import filthyFood from '../assets/images/projects/filthy-food-512.png';
+import filthyFoodWebp from '../assets/images/projects/filthy-food-512.webp';
+import federated from '../assets/images/projects/federated-512.png';
+import federatedWebp from '../assets/images/projects/federated-512.webp';
+import exoticCarTrader from '../assets/images/projects/exotic-car-trader-512.png';
+import exoticCarTraderWebp from '../assets/images/projects/exotic-car-trader-512.webp';
+import bcbsMain from '../assets/images/projects/bcbs-main.png';
+import bcbsMainWebp from '../assets/images/projects/bcbs-main.webp';
+import bcbsLitehouse from '../assets/images/projects/bcbs-litehouse.png';
+import bcbsLitehouseWebp from '../assets/images/projects/bcbs-litehouse.webp';
+import bcbsProviders from '../assets/images/projects/bcbs-providers.png';
+import bcbsProvidersWebp from '../assets/images/projects/bcbs-providers.webp';
+import voicepoolImg from '../assets/images/projects/voicepool.png';
+import voicepoolImgWebp from '../assets/images/projects/voicepool.webp';
+import branchBeaconImg from '../assets/images/projects/branch-beacon.png';
+import branchBeaconImgWebp from '../assets/images/projects/branch-beacon.webp';
+import patternArchiveDashboard from '../assets/images/projects/pattern-archive-dashboard.png';
+import patternArchiveDashboardWebp from '../assets/images/projects/pattern-archive-dashboard.webp';
+import patternArchiveWizard from '../assets/images/projects/pattern-archive-wizard-editor.png';
+import patternArchiveWizardWebp from '../assets/images/projects/pattern-archive-wizard-editor.webp';
+import patternArchiveLibrary from '../assets/images/projects/pattern-archive-library.png';
+import patternArchiveLibraryWebp from '../assets/images/projects/pattern-archive-library.webp';
+
+export {
+    generalProvision,
+    generalProvisionWebp,
+    trimAgency,
+    trimAgencyWebp,
+    cSolutions,
+    cSolutionsWebp,
+    filthyFood,
+    filthyFoodWebp,
+    federated,
+    federatedWebp,
+    exoticCarTrader,
+    exoticCarTraderWebp,
+    bcbsMain,
+    bcbsMainWebp,
+    bcbsLitehouse,
+    bcbsLitehouseWebp,
+    bcbsProviders,
+    bcbsProvidersWebp,
+    voicepoolImg,
+    voicepoolImgWebp,
+    branchBeaconImg,
+    branchBeaconImgWebp,
+    patternArchiveDashboard,
+    patternArchiveDashboardWebp,
+    patternArchiveWizard,
+    patternArchiveWizardWebp,
+    patternArchiveLibrary,
+    patternArchiveLibraryWebp
+};
+
+// ── Data arrays ───────────────────────────────────────────────────────────────
+
+export const CLIENT_PROJECTS: Project[] = [
+    {
+        title: 'T R I M Agency',
+        description: 'Web Development',
+        imageURL: trimAgency,
+        imageURLWebp: trimAgencyWebp,
+        url: '//www.trimagency.com/'
+    },
+    {
+        title: 'C Solutions',
+        description: 'Web Development',
+        imageURL: cSolutions,
+        imageURLWebp: cSolutionsWebp,
+        url: '//csolutions-us.com/'
+    },
+    {
+        title: 'Exotic Car Trader',
+        description: 'Web Development',
+        imageURL: exoticCarTrader,
+        imageURLWebp: exoticCarTraderWebp,
+        url: '//www.exoticcartrader.com/'
+    },
+    {
+        title: 'Federated Insurance',
+        description: 'Web Development',
+        imageURL: federated,
+        imageURLWebp: federatedWebp,
+        url: '//www.federated.ca/'
+    },
+    {
+        title: 'Filthy Food',
+        description: 'Ecommerce',
+        imageURL: filthyFood,
+        imageURLWebp: filthyFoodWebp,
+        url: '//filthyfood.com/'
+    },
+    {
+        title: 'General Provision',
+        description: 'Web Development',
+        imageURL: generalProvision,
+        imageURLWebp: generalProvisionWebp,
+        url: '//generalprovision.com/'
+    }
+];
+
+// FEATURED_PROJECTS and PERSONAL_PROJECTS contain JSX in their description
+// fields (anchor tags) and ReactNode imageSlot / actions, so they must be
+// composed in Projects.tsx where JSX is available.
+// The image assets are re-exported above for Projects.tsx to compose them.

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -93,21 +93,21 @@ export {
 export const CLIENT_PROJECTS: Project[] = [
     {
         title: 'T R I M Agency',
-        description: 'Web Development',
+        description: 'Agency Web App',
         imageURL: trimAgency,
         imageURLWebp: trimAgencyWebp,
         url: '//www.trimagency.com/'
     },
     {
         title: 'C Solutions',
-        description: 'Web Development',
+        description: 'Marketing Website',
         imageURL: cSolutions,
         imageURLWebp: cSolutionsWebp,
         url: '//csolutions-us.com/'
     },
     {
         title: 'Exotic Car Trader',
-        description: 'Web Development',
+        description: 'Ecommerce Web App',
         imageURL: exoticCarTrader,
         imageURLWebp: exoticCarTraderWebp,
         url: '//www.exoticcartrader.com/'
@@ -128,7 +128,7 @@ export const CLIENT_PROJECTS: Project[] = [
     },
     {
         title: 'General Provision',
-        description: 'Web Development',
+        description: 'Membership & Marketing Site',
         imageURL: generalProvision,
         imageURLWebp: generalProvisionWebp,
         url: '//generalprovision.com/'

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -1,0 +1,20 @@
+// ── Navigation ────────────────────────────────────────────────────────────────
+
+export const NAV_LINKS = [
+    { name: 'home', text: 'Home' },
+    { name: 'skills', text: 'Skills' },
+    { name: 'projects', text: 'Projects' },
+    { name: 'contact', text: 'Contact' }
+] as const;
+
+export type NavLink = (typeof NAV_LINKS)[number];
+
+// ── Resume ────────────────────────────────────────────────────────────────────
+
+export const RESUME_PATH = '/resources/miguel_lozano_resume_2024.pdf';
+
+// ── Key external URLs ─────────────────────────────────────────────────────────
+
+export const LINKEDIN_URL = 'https://www.linkedin.com/in/migueldot/';
+export const GITHUB_URL = '//github.com/MiguelDotL';
+export const DUOLINGO_URL = '//www.duolingo.com/profile/MiguelDotL';

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -1,0 +1,51 @@
+import claudeIcon from '../assets/images/icons/claude.svg';
+import pythonIcon from '../assets/images/icons/python.svg';
+import fastapiIcon from '../assets/images/icons/fastapi.svg';
+import html5Icon from '../assets/images/icons/html5.svg';
+import css3Icon from '../assets/images/icons/css3.svg';
+import mysqlIcon from '../assets/images/icons/mysql.svg';
+import postgresqlIcon from '../assets/images/icons/postgresql.svg';
+import mongodbIcon from '../assets/images/icons/mongodb.svg';
+import linuxIcon from '../assets/images/icons/linux.svg';
+
+// ── Type ──────────────────────────────────────────────────────────────────────
+
+export type Skill = {
+    name: string;
+    /** devicon class suffix (e.g. "javascript-plain"). When present, renders
+        a <i className={`devicon devicon-${class} colored`} />. */
+    class?: string;
+    /** Override devicon's CSS color with an explicit hex/rgb value. */
+    color?: string;
+    /** Path to a custom SVG/PNG icon (active state). Renders as <img>. */
+    iconPath?: string;
+    /** Path to a grayscale/inactive icon used for cross-fade. */
+    iconInactive?: string;
+};
+
+// ── Data ──────────────────────────────────────────────────────────────────────
+
+export const SKILLS: Skill[] = [
+    { name: 'Bash', class: 'bash-plain', color: '#44B04F' },
+    { name: 'HTML', class: 'html5-plain', iconPath: html5Icon },
+    { name: 'CSS', class: 'css3-plain', iconPath: css3Icon },
+    { name: 'JavaScript', class: 'javascript-plain' },
+    { name: 'TypeScript', class: 'typescript-plain' },
+    { name: 'jQuery', class: 'jquery-plain' },
+    { name: 'React', class: 'react-original' },
+    { name: 'Angular', class: 'angularjs-plain' },
+    { name: 'Node.js', class: 'nodejs-plain' },
+    { name: 'mongoDB', class: 'mongodb-plain', iconPath: mongodbIcon },
+    { name: 'PHP', class: 'php-plain' },
+    { name: 'MySQL', iconPath: mysqlIcon },
+    { name: 'Ruby', class: 'ruby-plain', color: '#940c00' },
+    { name: 'Ruby on Rails', class: 'rails-plain', color: '#940c00' },
+    { name: 'Python', iconPath: pythonIcon },
+    { name: 'FastAPI', iconPath: fastapiIcon },
+    { name: 'PostgreSQL', class: 'postgresql-plain', iconPath: postgresqlIcon },
+    { name: 'AWS', class: 'amazonwebservices-original' },
+    { name: 'Linux', class: 'linux-plain', color: '#EBC205', iconPath: linuxIcon },
+    { name: 'GitHub', class: 'github-original', color: '#9355AD' },
+    { name: 'Git', class: 'git-plain' },
+    { name: 'Claude', iconPath: claudeIcon, color: '#D97757' }
+];

--- a/src/data/socials.ts
+++ b/src/data/socials.ts
@@ -1,0 +1,70 @@
+import linkedInIcon from '../assets/images/icons/linked-in.svg';
+import twitterXIcon from '../assets/images/icons/twitter-x.svg';
+import githubIcon from '../assets/images/icons/github-2.svg';
+import codepenIcon from '../assets/images/icons/codepen-icon.svg';
+import npmIcon from 'devicon/icons/npm/npm-original-wordmark.svg';
+import codewarsIcon from '../assets/images/icons/codewars-icon.svg';
+import codecademyIcon from '../assets/images/icons/codecademy-icon.svg';
+import duolingoIcon from '../assets/images/icons/duolingo-icon.svg';
+
+// ── Type (re-exported from SocialIcons) ──────────────────────────────────────
+
+export type { SocialIconConfig } from '../components/SocialIcons';
+
+// ── Data ──────────────────────────────────────────────────────────────────────
+
+/** Social links shown in the NavBar (LinkedIn, X, GitHub). */
+export const NAV_SOCIALS = [
+    {
+        className: 'linked-in',
+        icon: linkedInIcon,
+        url: 'https://www.linkedin.com/in/migueldot/',
+        label: 'LinkedIn'
+    },
+    {
+        className: 'twitter',
+        icon: twitterXIcon,
+        url: '//twitter.com/MiguelDotL',
+        label: 'X (Twitter)'
+    },
+    {
+        className: 'github',
+        icon: githubIcon,
+        url: '//github.com/MiguelDotL',
+        label: 'GitHub'
+    }
+] as const satisfies import('../components/SocialIcons').SocialIconConfig[];
+
+/** Social links shown in the Footer (CodePen, npm, Codewars, Codecademy, Duolingo). */
+export const FOOTER_SOCIALS = [
+    {
+        className: 'codepen',
+        icon: codepenIcon,
+        url: '//codepen.io/MiguelDotL',
+        label: 'CodePen'
+    },
+    {
+        className: 'npm',
+        icon: npmIcon,
+        url: '//www.npmjs.com/~migueldotl',
+        label: 'npm'
+    },
+    {
+        className: 'codewars',
+        icon: codewarsIcon,
+        url: '//www.codewars.com/users/MiguelDotL',
+        label: 'Codewars'
+    },
+    {
+        className: 'codecademy',
+        icon: codecademyIcon,
+        url: '//www.codecademy.com/profiles/MiguelDotL',
+        label: 'Codecademy'
+    },
+    {
+        className: 'duolingo',
+        icon: duolingoIcon,
+        url: '//www.duolingo.com/profile/MiguelDotL',
+        label: 'Duolingo'
+    }
+] as const satisfies import('../components/SocialIcons').SocialIconConfig[];

--- a/src/hooks/useInViewOnce.ts
+++ b/src/hooks/useInViewOnce.ts
@@ -1,0 +1,43 @@
+import { useState, useCallback } from 'react';
+import type { RefCallback } from 'react';
+
+/**
+ * Fires once when the attached element enters the viewport, then disconnects.
+ * Returns a callback ref (not a ref object) to avoid needing a useEffect to
+ * observe: the callback fires on mount, letting the hook wire up the IO
+ * immediately without a separate effect.
+ *
+ * Usage:
+ *   const { ref, inView } = useInViewOnce<HTMLDivElement>();
+ *   return <div ref={ref} className={inView ? 'visible' : ''} />;
+ */
+function useInViewOnce<T extends Element>(): { ref: RefCallback<T>; inView: boolean } {
+    const [inView, setInView] = useState(false);
+
+    const ref: RefCallback<T> = useCallback((el) => {
+        if (!el) return;
+
+        // SSR / old test envs without IO — immediately treat as in-view.
+        if (typeof IntersectionObserver === 'undefined') {
+            setInView(true);
+            return;
+        }
+
+        const io = new IntersectionObserver(([entry]) => {
+            if (entry.isIntersecting) {
+                setInView(true);
+                io.disconnect();
+            }
+        });
+
+        io.observe(el);
+
+        // No cleanup returned from a RefCallback — the IO is disconnected on
+        // first intersection, so it self-cleans. If the element unmounts before
+        // it enters the viewport the IO is GC'd with it.
+    }, []);
+
+    return { ref, inView };
+}
+
+export default useInViewOnce;


### PR DESCRIPTION
## Summary

- **1.1 Data extraction** — `src/data/{projects,skills,socials,site}.ts` wired to all consumers (Projects.stories, SkillsCarousel, NavBar, Footer, HeroContent). Removes duplicate inline arrays and hard-coded URLs.
- **1.2 useInViewOnce + dep drop** — Shared callback-ref hook replaces `useInView({ triggerOnce: true })` in Skills, ContactMe, Projects, and HeroContent (migrated from manual `useRef`/`useEffect` IO pattern). `react-intersection-observer` dropped from package.json.
- **1.3 ResponsiveImage** — New component encapsulates the `<picture><source /><img />` pattern. Replaces 8 sites. Projects' "background image" was a real `<img>` element (not CSS background-image) — replaced correctly.
- **1.4 Animation constants** — `FADE_IN` / `FADE_IN_SLOWER` in `src/constants/animationClasses.ts`. Replaces literals in 4 components. These match `@keyframes` in `src/index.css`; `animate.css` is not installed.

Closes #143

## Test plan
- [ ] `npm run lint` — clean
- [ ] `npx tsc --noEmit` — clean
- [ ] `npm test` — 134/134 tests pass
- [ ] `npm run build` — clean; bundle shrinks ~3 KB gzipped across the 3 lazy chunks that previously imported `react-intersection-observer`
- [ ] Chromatic — empty visual diff (no DOM changes; pure refactor)