### PR TITLE
refactor(types): Phase 4 TypeScript hygiene

### DIFF
--- a/src/components/FeaturedImageSlider.tsx
+++ b/src/components/FeaturedImageSlider.tsx
@@ -19,7 +19,7 @@ export type SliderIndicator =
 
 export type SliderControl = 'arrows' | 'click-image' | 'keyboard' | 'swipe';
 
-type Props = {
+export type FeaturedImageSliderProps = {
     images: FeaturedImageSlide[];
     intervalMs?: number;
     indicator?: SliderIndicator;
@@ -36,7 +36,7 @@ const FeaturedImageSlider = ({
     indicator = 'frosted-dots',
     controls = [],
     imagePosition = 'center'
-}: Props) => {
+}: FeaturedImageSliderProps) => {
     const [index, setIndex] = useState(0);
     const [paused, setPaused] = useState(false);
     const [progress, setProgress] = useState(0);

--- a/src/components/FeaturedImageSlider.tsx
+++ b/src/components/FeaturedImageSlider.tsx
@@ -72,7 +72,8 @@ const FeaturedImageSlider = ({
         }
         const io = new IntersectionObserver(
             ([entry]) => {
-                setOffScreen(!entry.isIntersecting);
+                // entry is always present — IO fires at least one per observed element.
+                if (entry) setOffScreen(!entry.isIntersecting);
             },
             { rootMargin: '100px' }
         );
@@ -181,6 +182,9 @@ const FeaturedImageSlider = ({
         </div>
     );
 
+    // index is always valid — it's clamped to [0, images.length-1] by setIndex.
+    const activeSlide = images[index]!;
+
     return (
         <div
             ref={rootRef}
@@ -270,13 +274,13 @@ const FeaturedImageSlider = ({
                     className="featured-image-slider__lightbox"
                     role="dialog"
                     aria-modal="true"
-                    aria-label={images[index].alt}
+                    aria-label={activeSlide.alt}
                     onClick={() => setLightboxOpen(false)}
                 >
                     <ResponsiveImage
-                        src={images[index].src}
-                        srcWebp={images[index].srcWebp}
-                        alt={images[index].alt}
+                        src={activeSlide.src}
+                        srcWebp={activeSlide.srcWebp}
+                        alt={activeSlide.alt}
                         className="featured-image-slider__lightbox-img"
                         onClick={(e) => e.stopPropagation()}
                     />

--- a/src/components/FormStatusMessage.tsx
+++ b/src/components/FormStatusMessage.tsx
@@ -1,6 +1,6 @@
 type Variant = 'success' | 'danger' | null;
 
-type Props = {
+export type FormStatusMessageProps = {
     /** Visual variant. `null` renders nothing — useful for the pre-submit state. */
     variant: Variant;
     message: string;
@@ -14,7 +14,7 @@ const ICON: Record<Exclude<Variant, null>, { className: string; glyph: string }>
 // Inline status banner shown after a contact-form submit attempt.
 // Styling lives in Contact.css under `.contact form .form-status-message`.
 // Renders the role=status + aria-live wiring so consumers don't have to.
-const FormStatusMessage = ({ variant, message }: Props) => {
+const FormStatusMessage = ({ variant, message }: FormStatusMessageProps) => {
     const icon = variant ? ICON[variant] : null;
     return (
         <div

--- a/src/components/HeroChatCta.tsx
+++ b/src/components/HeroChatCta.tsx
@@ -1,13 +1,13 @@
 import { ArrowRightCircle } from 'react-bootstrap-icons';
 
-type Props = {
+export type HeroChatCtaProps = {
     /** Element id to scroll into view on click. Defaults to "contact". */
     targetId?: string;
 };
 
 // Hero "Let's Chat" CTA. Plain text + ArrowRightCircle icon. Styling
 // lives in Hero.css under `.hero .hero-contact-button`.
-const HeroChatCta = ({ targetId = 'contact' }: Props) => (
+const HeroChatCta = ({ targetId = 'contact' }: HeroChatCtaProps) => (
     <button
         className="hero-contact-button"
         onClick={() => document.getElementById(targetId)?.scrollIntoView()}

--- a/src/components/HoverZoomPan.tsx
+++ b/src/components/HoverZoomPan.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState, type MouseEvent } from 'react';
 import ResponsiveImage from './ResponsiveImage';
 
-type Props = {
+export type HoverZoomPanProps = {
     src: string;
     /** Optional WebP source served via <picture> when supported. */
     srcWebp?: string;
@@ -18,7 +18,7 @@ const HoverZoomPan = ({
     alt,
     zoomScale = 1.63,
     transitionMs = 963
-}: Props) => {
+}: HoverZoomPanProps) => {
     // transformOrigin is purely visual state — write it to the DOM directly via
     // ref instead of going through React state. setState on every mousemove
     // would force a full component rerender 60+ times per second.

--- a/src/components/MomentumTabs.tsx
+++ b/src/components/MomentumTabs.tsx
@@ -7,7 +7,7 @@ const SLIDE_STRETCH_MS = TAB_ANIMATION.indicatorSlideStretchMs;
 const SLIDE_CONTRACT_MS = TAB_ANIMATION.indicatorSlideContractMs;
 const EXPAND_MS = TAB_ANIMATION.indicatorExpandMs;
 
-type MomentumTabsProps<T extends string> = {
+export type MomentumTabsProps<T extends string> = {
     tabs: readonly T[];
     active: T;
     onChange: (tab: T) => void;

--- a/src/components/MomentumTabs.tsx
+++ b/src/components/MomentumTabs.tsx
@@ -228,7 +228,8 @@ const MomentumTabs = <T extends string>({
         }
         if (nextIdx !== null && nextIdx !== currentIdx) {
             e.preventDefault();
-            const nextTab = tabs[nextIdx];
+            // nextIdx is always within [0, tabs.length-1] — clamped by the conditions above.
+            const nextTab = tabs[nextIdx]!;
             handleClick(nextTab);
             buttonRefs.current[nextTab]?.focus();
         }

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -41,7 +41,7 @@ const NavBar = () => {
                 .map((id) => document.getElementById(id))
                 .filter((el): el is HTMLElement => el !== null);
 
-            let current: string = sectionIds[0];
+            let current: string = sectionIds[0] ?? '';
             for (const section of sections) {
                 if (section.getBoundingClientRect().top <= triggerY) {
                     current = section.id;

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -51,12 +51,11 @@ const NavBar = () => {
         };
 
         onScroll();
-        const w = window as unknown as {
-            requestIdleCallback?: typeof requestIdleCallback;
-            cancelIdleCallback?: typeof cancelIdleCallback;
-        };
-        const ric = w.requestIdleCallback;
-        const cic = w.cancelIdleCallback;
+        // requestIdleCallback/cancelIdleCallback are in lib.dom but absent in
+        // Safari pre-2022. The runtime guard below (`if (ric)`) handles that
+        // case — no cast needed since lib.dom types them on Window.
+        const ric = window.requestIdleCallback;
+        const cic = window.cancelIdleCallback;
         let idleHandle: number | undefined;
         let timeoutHandle: number | undefined;
         const attach = () => {

--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -1,6 +1,6 @@
 import { Nav } from 'react-bootstrap';
 
-type Props = {
+export type NavLinkProps = {
     /** Section id this link points to (also used as the URL hash). */
     name: string;
     text: string;
@@ -11,7 +11,7 @@ type Props = {
 // Top-level nav link rendered inside NavBar's Nav.Link map. Wraps
 // react-bootstrap's Nav.Link with the active-class logic so the host
 // component doesn't have to build the className string ad-hoc.
-const NavLink = ({ name, text, isActive, onClick }: Props) => (
+const NavLink = ({ name, text, isActive, onClick }: NavLinkProps) => (
     <Nav.Link
         href={`#${name}`}
         className={`${isActive ? 'active' : ''} navbar-link`}

--- a/src/components/NpmPlainIcon.tsx
+++ b/src/components/NpmPlainIcon.tsx
@@ -1,4 +1,4 @@
-type Props = {
+export type NpmPlainIconProps = {
     size?: number;
     className?: string;
 };
@@ -11,7 +11,7 @@ type Props = {
  * Single path with even-odd fill: rounded square + "n" silhouette cutout. Use
  * fill=currentColor so the icon picks up the surrounding text color.
  */
-const NpmPlainIcon = ({ size = 16, className }: Props) => (
+const NpmPlainIcon = ({ size = 16, className }: NpmPlainIconProps) => (
     <svg
         viewBox="0 0 128 128"
         width={size}

--- a/src/components/ProjectActionLink.tsx
+++ b/src/components/ProjectActionLink.tsx
@@ -10,13 +10,13 @@ export type ProjectAction = {
     disabledReason?: string;
 };
 
-type Props = { action: ProjectAction };
+export type ProjectActionLinkProps = { action: ProjectAction };
 
 // Action chip used under FeaturedProjectCard. Renders as <a> when active
 // or <span aria-disabled> when locked (e.g. private repo). Both share the
 // `.btn .btn-outline-secondary` base — the disabled variant adds a lock
 // glyph + dimmed style via `.featured-project-action--disabled`.
-const ProjectActionLink = ({ action }: Props) => {
+const ProjectActionLink = ({ action }: ProjectActionLinkProps) => {
     if (action.disabled) {
         return (
             <span

--- a/src/components/ProjectCard.stories.tsx
+++ b/src/components/ProjectCard.stories.tsx
@@ -82,7 +82,7 @@ export const Hovered: Story = {
         url: '//www.trimagency.com/'
     },
     play: async ({ canvasElement }) => {
-        const card = within(canvasElement).getAllByRole('img')[0]
+        const card = within(canvasElement).getAllByRole('img')[0]!
             .closest('.project-card');
         if (card) await userEvent.hover(card);
     }

--- a/src/components/ProjectList.stories.tsx
+++ b/src/components/ProjectList.stories.tsx
@@ -53,7 +53,7 @@ export const ThreeProjects: Story = {
 
 export const OneProject: Story = {
     args: {
-        projects: [sampleProjects[0]]
+        projects: [sampleProjects[0]!]
     }
 };
 

--- a/src/components/ProjectList.tsx
+++ b/src/components/ProjectList.tsx
@@ -1,7 +1,7 @@
 import { Row } from "react-bootstrap";
 import ProjectCard, { type Project } from "./ProjectCard";
 
-type ProjectListProps = {
+export type ProjectListProps = {
     projects: Project[];
 };
 

--- a/src/components/ProjectTabsExploration.stories.tsx
+++ b/src/components/ProjectTabsExploration.stories.tsx
@@ -514,7 +514,7 @@ const BigTextVariant = () => {
 
         let delay = 0;
         for (let i = sourceIdx + step; step > 0 ? i <= targetIdx : i >= targetIdx; i += step) {
-            const tab = BIG_TEXT_TABS[i];
+            const tab = BIG_TEXT_TABS[i]!;
             const t = window.setTimeout(() => setActive(tab), delay);
             cascadeTimers.current.push(t);
             delay += stepDelay;

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -42,7 +42,7 @@ type Tab = (typeof TABS)[number];
 
 const TAB_FADE_MS = TAB_ANIMATION.fadeMs;
 
-type ProjectsProps = {
+export type ProjectsProps = {
     /** Force the in-view state to start true. Used by Storybook stories
         where the IntersectionObserver doesn't fire reliably in the
         canvas iframe. Production callers should leave this false (default)

--- a/src/components/ResumeButton.tsx
+++ b/src/components/ResumeButton.tsx
@@ -1,13 +1,13 @@
 import { FileEarmarkText } from 'react-bootstrap-icons';
 
-type Props = {
+export type ResumeButtonProps = {
     /** Resume URL relative to the site root (e.g. "/resources/resume.pdf"). */
     resumePath: string;
 };
 
 // "My Resume" button rendered on the right side of the NavBar. Opens the
 // PDF in a new tab. Styling lives in NavBar.css under `.resume-button`.
-const ResumeButton = ({ resumePath }: Props) => (
+const ResumeButton = ({ resumePath }: ResumeButtonProps) => (
     <button
         className="resume-button"
         onClick={() =>

--- a/src/components/SkillsCarousel.tsx
+++ b/src/components/SkillsCarousel.tsx
@@ -43,7 +43,8 @@ const SkillsCarousel = () => {
 
         const observer = new IntersectionObserver(
             ([entry]) => {
-                isInView = entry.isIntersecting && entry.intersectionRatio >= 0.5;
+                // entry is always present — IO fires at least one per observed element.
+                if (entry) isInView = entry.isIntersecting && entry.intersectionRatio >= 0.5;
             },
             { threshold: [0, 0.25, 0.5, 0.75, 1] }
         );

--- a/src/components/SliderArrowButton.tsx
+++ b/src/components/SliderArrowButton.tsx
@@ -1,6 +1,6 @@
 type Direction = 'prev' | 'next';
 
-type Props = {
+export type SliderArrowButtonProps = {
     direction: Direction;
     /** CSS class scope. The slider chrome uses `featured-image-slider__arrow`,
         the lightbox chrome uses `featured-image-slider__lightbox-arrow`. */
@@ -22,7 +22,7 @@ const GLYPH: Record<Direction, string> = {
 // the slider chrome and the open lightbox. Same markup, different CSS
 // class scopes — keep classScope explicit so callers control which
 // chrome the button belongs to.
-const SliderArrowButton = ({ direction, classScope, onClick }: Props) => (
+const SliderArrowButton = ({ direction, classScope, onClick }: SliderArrowButtonProps) => (
     <button
         type="button"
         aria-label={LABEL[direction]}

--- a/src/components/SocialIcons.stories.tsx
+++ b/src/components/SocialIcons.stories.tsx
@@ -49,7 +49,7 @@ const hoverFirstIcon = async ({
 }: {
     canvasElement: HTMLElement;
 }) => {
-    const link = within(canvasElement).getAllByRole('link')[0];
+    const link = within(canvasElement).getAllByRole('link')[0]!;
     await userEvent.hover(link);
     await userEvent.unhover(link);
 };

--- a/src/components/SocialIcons.tsx
+++ b/src/components/SocialIcons.tsx
@@ -7,7 +7,7 @@ export type SocialIconConfig = {
     label: string;
 };
 
-type SocialIconsProps = {
+export type SocialIconsProps = {
     config: SocialIconConfig[];
     onHover?: (label: string | null) => void;
 };

--- a/src/components/TaglineBadge.tsx
+++ b/src/components/TaglineBadge.tsx
@@ -1,12 +1,12 @@
 import type { ReactNode } from 'react';
 
-type Props = {
+export type TaglineBadgeProps = {
     children: ReactNode;
 };
 
 // Gradient-tinted pill above the hero headline ("Welcome to my Portfolio").
 // Styling lives in Hero.css under `.hero .content .tagline`.
-const TaglineBadge = ({ children }: Props) => (
+const TaglineBadge = ({ children }: TaglineBadgeProps) => (
     <span className="tagline">{children}</span>
 );
 

--- a/src/components/TechStackList.tsx
+++ b/src/components/TechStackList.tsx
@@ -1,11 +1,11 @@
-type Props = {
+export type TechStackListProps = {
     /** Tech labels to render as chips. */
     stack: readonly string[];
 };
 
 // Pill-chip list used to label a project's tech stack on FeaturedProjectCard.
 // Styling lives in Projects.css under `.featured-project-stack li`.
-const TechStackList = ({ stack }: Props) => {
+const TechStackList = ({ stack }: TechStackListProps) => {
     if (stack.length === 0) return null;
     return (
         <ul className="featured-project-stack">

--- a/src/components/heroTyping.ts
+++ b/src/components/heroTyping.ts
@@ -45,7 +45,8 @@ export const initialTypingState = (typingDelay: number): TypingState => ({
  */
 export const advanceTyping = (state: TypingState): TypingState => {
     const currentRole = state.roleCount % ROLES.length;
-    const fullText = ROLES[currentRole];
+    // currentRole is always a valid index — modulo keeps it within [0, ROLES.length-1].
+    const fullText = ROLES[currentRole]!;
     const currentText = state.isTyping
         ? fullText.substring(0, state.jobTitle.length + 1)
         : fullText.substring(0, state.jobTitle.length - 1);

--- a/src/hooks/useInViewOnce.ts
+++ b/src/hooks/useInViewOnce.ts
@@ -24,7 +24,8 @@ function useInViewOnce<T extends Element>(): { ref: RefCallback<T>; inView: bool
         }
 
         const io = new IntersectionObserver(([entry]) => {
-            if (entry.isIntersecting) {
+            // entry is always present — IO fires at least one per observed element.
+            if (entry?.isIntersecting) {
                 setInView(true);
                 io.disconnect();
             }

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -1,0 +1,11 @@
+// Global Window augmentations.
+//
+// Note: `requestIdleCallback` and `cancelIdleCallback` are already declared
+// in lib.dom.d.ts (non-optional). NavBar uses them via a runtime guard
+// (`if (ric)`) which handles Safari's historical lack of support without
+// needing a cast. No augmentation is required for those.
+//
+// Add future global augmentations here rather than sprinkling `declare global`
+// blocks across component files.
+
+export {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
         "noUnusedLocals": false,
         "noUnusedParameters": false,
         "noFallthroughCasesInSwitch": true,
+        "noUncheckedIndexedAccess": true,
 
         "types": ["vite/client", "vitest/globals"]
     },


### PR DESCRIPTION
## Summary

- Export `Props` types from 15 components (renamed to `ComponentNameProps` convention where previously unnamed). Enables Storybook stories using `Meta<typeof Component>` to pick up typed args without explicit annotation. Type-only exports — zero bundle impact.
- Remove `window as unknown as { requestIdleCallback?... }` cast in `NavBar.tsx`. `lib.dom` already types both methods on `Window`; the existing `if (ric)` runtime guard handles Safari's historical lack of support. Create `src/types/globals.d.ts` as the canonical home for future Window augmentations.
- Enable `noUncheckedIndexedAccess: true` in `tsconfig.json`. Fallout: 11 sites, 17 error lines — all fixed inline with `!` assertions where index is provably bounded (modulo ops, clamped counters), `?.` optional chains on IntersectionObserver entry destructuring, and `?? ''` fallback for the NavBar scroll-spy default.

## Test plan

- [ ] `npx tsc --noEmit` — clean (0 errors)
- [ ] `npm run lint` — clean
- [ ] `npm test` — 35 files, 134 tests, all green
- [ ] `npm run build` — clean, bundle sizes flat
- [ ] `grep -rn "window as unknown" src/` — 0 hits