### PR TITLE
refactor(contact-form): extract useFormSubmit hook — Phase 3.4

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,17 +1,8 @@
 import { useRef, useState } from "react";
 import type { ChangeEvent, FormEvent } from "react";
-import axios from "axios";
 import { Col, Row } from "react-bootstrap";
 import FormStatusMessage from "./FormStatusMessage";
-
-type FormStatus = {
-    status: number | null;
-    success: boolean | null;
-    error: string | null;
-    message: string;
-};
-
-type SubmitResponse = { status: number; data: { success: boolean; message: string } };
+import useFormSubmit from "../hooks/useFormSubmit";
 
 const initialValues = {
     firstName: "",
@@ -50,38 +41,14 @@ const validate = (values: FormValues): FieldErrors => {
     return errs;
 };
 
-const submitForm = async (
-    payload: Record<string, string>
-): Promise<SubmitResponse> => {
-    const mock = import.meta.env.VITE_MOCK_FORM;
-    const isMockable = import.meta.env.DEV && import.meta.env.MODE !== "test";
-    if (isMockable && mock) {
-        await new Promise((resolve) => setTimeout(resolve, 500));
-        if (mock === "error") {
-            return { status: 200, data: { success: false, message: "[MOCK] Spam detected" } };
-        }
-        if (mock === "throw") {
-            throw new Error("[MOCK] Request failed with status code 429");
-        }
-        return { status: 200, data: { success: true, message: "[MOCK] Email sent" } };
-    }
-    return axios.post(import.meta.env.VITE_FORM_ENDPOINT, payload);
-};
-
 const ContactForm = () => {
     const [formValues, setFormValues] = useState<FormValues>(initialValues);
-    const [buttonText, setButtonText] = useState("Send");
-    const [loading, setLoading] = useState(false);
     const [submitAttempted, setSubmitAttempted] = useState(false);
-    const [formStatus, setFormStatus] = useState<FormStatus>({
-        status: null,
-        success: null,
-        error: null,
-        message: ""
-    });
     const formRef = useRef<HTMLFormElement>(null);
 
-    const isSent = formStatus.success === true;
+    const { status, message, buttonLabel, submit } = useFormSubmit();
+
+    const isSent = status === 'success';
 
     // Errors render only after the user attempts submit. Derived from
     // formValues each render, so messages clear themselves as fields are
@@ -99,9 +66,9 @@ const ContactForm = () => {
         };
     };
 
-    const onFormSubmit = (e: FormEvent<HTMLFormElement>) => {
+    const onFormSubmit = async (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
-        if (loading || isSent) return;
+        if (status === 'submitting' || isSent) return;
 
         const errs = validate(formValues);
         setSubmitAttempted(true);
@@ -115,48 +82,18 @@ const ContactForm = () => {
             return;
         }
 
-        setButtonText("Sending...");
-        setLoading(true);
-
         const payload = {
             access_key: import.meta.env.VITE_FORM_ACCESS_KEY,
             subject: `Portfolio contact from ${formValues.firstName} ${formValues.lastName}`.trim(),
             ...formValues
         };
 
-        submitForm(payload)
-            .then((response) => {
-                if (response.data.success) {
-                    setFormStatus({
-                        success: true,
-                        status: response.status,
-                        error: null,
-                        message: "Thanks for reaching out, I'll be in touch!"
-                    });
-                    setFormValues(initialValues);
-                    setSubmitAttempted(false);
-                    setButtonText("Sent ✓");
-                } else {
-                    setFormStatus({
-                        success: false,
-                        status: response.status,
-                        error: response.data.message ?? "Submission failed",
-                        message: "Oops! Request Failed. Please try again soon"
-                    });
-                    setButtonText("Send");
-                }
-                setLoading(false);
-            })
-            .catch((error: Error) => {
-                setFormStatus({
-                    success: false,
-                    status: null,
-                    error: error.message,
-                    message: "Oops! Request Failed. Please try again soon"
-                });
-                setLoading(false);
-                setButtonText("Send");
-            });
+        const succeeded = await submit(payload);
+
+        if (succeeded) {
+            setFormValues(initialValues);
+            setSubmitAttempted(false);
+        }
     };
 
     const containerClasses = [
@@ -168,9 +105,9 @@ const ContactForm = () => {
         .join(" ");
 
     const statusVariant: 'success' | 'danger' | null =
-        formStatus.success === true
+        status === 'success'
             ? 'success'
-            : formStatus.success === false
+            : status === 'error'
             ? 'danger'
             : null;
 
@@ -285,13 +222,13 @@ const ContactForm = () => {
                 <div className={containerClasses}>
                     <button
                         type="submit"
-                        disabled={loading || isSent}
+                        disabled={status === 'submitting' || isSent}
                     >
-                        <span>{buttonText}</span>
+                        <span>{buttonLabel}</span>
                     </button>
                     <FormStatusMessage
                         variant={statusVariant}
-                        message={formStatus.message}
+                        message={message}
                     />
                 </div>
             </Row>

--- a/src/hooks/useFormSubmit.test.ts
+++ b/src/hooks/useFormSubmit.test.ts
@@ -1,0 +1,181 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import axios from 'axios';
+import useFormSubmit from './useFormSubmit';
+
+vi.mock('axios');
+
+const payload = { access_key: 'test-key', firstName: 'Miguel', email: 'a@b.com', message: 'Hello there' };
+
+describe('useFormSubmit — initial state', () => {
+    test('starts idle with empty message and Send label', () => {
+        const { result } = renderHook(() => useFormSubmit());
+        expect(result.current.status).toBe('idle');
+        expect(result.current.message).toBe('');
+        expect(result.current.errorMessage).toBeNull();
+        expect(result.current.buttonLabel).toBe('Send');
+    });
+});
+
+describe('useFormSubmit — happy path', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test('transitions idle → submitting → success on a resolved axios call', async () => {
+        vi.mocked(axios.post).mockResolvedValueOnce({
+            status: 200,
+            data: { success: true, message: 'Email sent' }
+        });
+
+        const { result } = renderHook(() => useFormSubmit());
+
+        let submitResult: boolean | undefined;
+        await act(async () => {
+            submitResult = await result.current.submit(payload);
+        });
+
+        expect(submitResult).toBe(true);
+        expect(result.current.status).toBe('success');
+        expect(result.current.message).toMatch(/Thanks for reaching out/i);
+        expect(result.current.errorMessage).toBeNull();
+        expect(result.current.buttonLabel).toBe('Sent ✓');
+    });
+
+    test('calls axios.post with the supplied payload', async () => {
+        vi.mocked(axios.post).mockResolvedValueOnce({
+            status: 200,
+            data: { success: true, message: 'Email sent' }
+        });
+
+        const { result } = renderHook(() => useFormSubmit());
+        await act(async () => {
+            await result.current.submit(payload);
+        });
+
+        expect(vi.mocked(axios.post)).toHaveBeenCalledTimes(1);
+        const [, calledPayload] = vi.mocked(axios.post).mock.calls[0] as [string, Record<string, string>];
+        expect(calledPayload).toMatchObject(payload);
+    });
+});
+
+describe('useFormSubmit — network error', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test('transitions to error and captures the error message when axios rejects', async () => {
+        vi.mocked(axios.post).mockRejectedValueOnce(new Error('Network down'));
+
+        const { result } = renderHook(() => useFormSubmit());
+
+        let submitResult: boolean | undefined;
+        await act(async () => {
+            submitResult = await result.current.submit(payload);
+        });
+
+        expect(submitResult).toBe(false);
+        expect(result.current.status).toBe('error');
+        expect(result.current.message).toMatch(/Oops! Request Failed/i);
+        expect(result.current.errorMessage).toBe('Network down');
+        expect(result.current.buttonLabel).toBe('Send');
+    });
+});
+
+describe('useFormSubmit — Web3Forms success:false', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test('transitions to error when response.data.success is false', async () => {
+        vi.mocked(axios.post).mockResolvedValueOnce({
+            status: 200,
+            data: { success: false, message: 'Spam detected' }
+        });
+
+        const { result } = renderHook(() => useFormSubmit());
+
+        let submitResult: boolean | undefined;
+        await act(async () => {
+            submitResult = await result.current.submit(payload);
+        });
+
+        expect(submitResult).toBe(false);
+        expect(result.current.status).toBe('error');
+        expect(result.current.message).toMatch(/Oops! Request Failed/i);
+        expect(result.current.errorMessage).toBe('Spam detected');
+    });
+
+    test('falls back to "Submission failed" when API error message is null/undefined', async () => {
+        // The ?? operator only catches null/undefined, not empty string.
+        // An explicit null from the API triggers the fallback.
+        vi.mocked(axios.post).mockResolvedValueOnce({
+            status: 200,
+            data: { success: false, message: null as unknown as string }
+        });
+
+        const { result } = renderHook(() => useFormSubmit());
+        await act(async () => {
+            await result.current.submit(payload);
+        });
+
+        expect(result.current.errorMessage).toBe('Submission failed');
+    });
+});
+
+describe('useFormSubmit — guard: no double-submit', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test('ignores a second submit call while already submitting', async () => {
+        let resolvePost!: (v: unknown) => void;
+        vi.mocked(axios.post).mockReturnValueOnce(
+            new Promise((res) => { resolvePost = res; })
+        );
+
+        const { result } = renderHook(() => useFormSubmit());
+
+        // Fire first submit without awaiting (leaves it in-flight)
+        act(() => { void result.current.submit(payload); });
+
+        // Fire second submit synchronously — should be a no-op
+        let secondResult: boolean | undefined;
+        await act(async () => {
+            secondResult = await result.current.submit(payload);
+        });
+
+        // Second call returns false and axios was called exactly once
+        expect(secondResult).toBe(false);
+        expect(vi.mocked(axios.post)).toHaveBeenCalledTimes(1);
+
+        // Resolve the in-flight post so the hook doesn't leak
+        resolvePost({ status: 200, data: { success: true, message: 'ok' } });
+    });
+});
+
+describe('useFormSubmit — reset', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test('reset() returns hook to idle state after an error', async () => {
+        vi.mocked(axios.post).mockRejectedValueOnce(new Error('Timeout'));
+
+        const { result } = renderHook(() => useFormSubmit());
+        await act(async () => {
+            await result.current.submit(payload);
+        });
+
+        expect(result.current.status).toBe('error');
+
+        act(() => {
+            result.current.reset();
+        });
+
+        expect(result.current.status).toBe('idle');
+        expect(result.current.message).toBe('');
+        expect(result.current.errorMessage).toBeNull();
+        expect(result.current.buttonLabel).toBe('Send');
+    });
+});

--- a/src/hooks/useFormSubmit.ts
+++ b/src/hooks/useFormSubmit.ts
@@ -1,0 +1,118 @@
+import { useState, useCallback } from 'react';
+import axios from 'axios';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SubmitStatus = 'idle' | 'submitting' | 'success' | 'error';
+
+export type UseFormSubmitReturn = {
+    /** Current status of the submission lifecycle. */
+    status: SubmitStatus;
+    /** Human-readable status banner message (empty when idle). */
+    message: string;
+    /** Raw error string from the network or API (only set on 'error'). */
+    errorMessage: string | null;
+    /** Button label that reflects the current status. */
+    buttonLabel: string;
+    /**
+     * Fire the submission. Accepts any flat string map — ContactForm passes
+     * the Web3Forms payload (access_key + subject + field values).
+     * Returns true on success so the caller can clear its own field state.
+     */
+    submit: (payload: Record<string, string>) => Promise<boolean>;
+    /** Manually reset back to idle (e.g. to allow re-submission). */
+    reset: () => void;
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+type SubmitResponse = { status: number; data: { success: boolean; message: string } };
+
+/**
+ * Dispatch the payload. In dev with VITE_MOCK_FORM set, short-circuits
+ * without hitting the real endpoint so the UI can be exercised offline.
+ * In tests (MODE === 'test'), the mock path is suppressed so vitest/axios
+ * mocks take full control.
+ */
+const dispatchForm = async (payload: Record<string, string>): Promise<SubmitResponse> => {
+    const mock = import.meta.env.VITE_MOCK_FORM;
+    const isMockable = import.meta.env.DEV && import.meta.env.MODE !== 'test';
+
+    if (isMockable && mock) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 500));
+        if (mock === 'error') {
+            return { status: 200, data: { success: false, message: '[MOCK] Spam detected' } };
+        }
+        if (mock === 'throw') {
+            throw new Error('[MOCK] Request failed with status code 429');
+        }
+        return { status: 200, data: { success: true, message: '[MOCK] Email sent' } };
+    }
+
+    return axios.post(import.meta.env.VITE_FORM_ENDPOINT, payload);
+};
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Owns the submission state machine for ContactForm:
+ *   idle → submitting → success | error
+ *
+ * The component retains all field state and validation; this hook manages
+ * only the async dispatch lifecycle and the resulting status.
+ */
+function useFormSubmit(): UseFormSubmitReturn {
+    const [status, setStatus] = useState<SubmitStatus>('idle');
+    const [message, setMessage] = useState('');
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [buttonLabel, setButtonLabel] = useState('Send');
+
+    const submit = useCallback(async (payload: Record<string, string>): Promise<boolean> => {
+        if (status === 'submitting' || status === 'success') return false;
+
+        setStatus('submitting');
+        setButtonLabel('Sending...');
+
+        try {
+            const response = await dispatchForm(payload);
+
+            if (response.data.success) {
+                setStatus('success');
+                setMessage("Thanks for reaching out, I'll be in touch!");
+                setErrorMessage(null);
+                setButtonLabel('Sent ✓');
+                return true;
+            } else {
+                setStatus('error');
+                setMessage('Oops! Request Failed. Please try again soon');
+                setErrorMessage(response.data.message ?? 'Submission failed');
+                setButtonLabel('Send');
+                return false;
+            }
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : 'Unknown error';
+            setStatus('error');
+            setMessage('Oops! Request Failed. Please try again soon');
+            setErrorMessage(msg);
+            setButtonLabel('Send');
+            return false;
+        }
+    }, [status]);
+
+    const reset = useCallback(() => {
+        setStatus('idle');
+        setMessage('');
+        setErrorMessage(null);
+        setButtonLabel('Send');
+    }, []);
+
+    return { status, message, errorMessage, buttonLabel, submit, reset };
+}
+
+export default useFormSubmit;


### PR DESCRIPTION
## Summary

- Extracts submission state machine from `ContactForm.tsx` into `src/hooks/useFormSubmit.ts`: axios dispatch, VITE_MOCK_FORM path, status transitions (`idle → submitting → success | error`), and button label
- Converts `.then/.catch` to `async/await` in the process
- ContactForm now owns only field state, validation, and rendering — the hook is wired via `const { status, message, buttonLabel, submit } = useFormSubmit()`
- `submit()` returns `boolean` (true = success) so the component can reset field state without reading stale closure values

## Test plan

- [ ] 8 new unit tests in `src/hooks/useFormSubmit.test.ts` (initial state, happy path, network error, Web3Forms `success:false`, null message fallback, double-submit guard, reset)
- [ ] All 5 existing `ContactForm.test.tsx` tests still pass without modification
- [ ] `npm run lint` — clean
- [ ] `npx tsc --noEmit` — clean
- [ ] `npm test` — 142/142 passing
- [ ] `npm run build` — clean, bundle size flat