### PR TITLE
refactor(tabs): split MomentumTabs — extract useTabAnimation hook + computeIndicatorPath module

### DIFF
--- a/src/components/MomentumTabs.tsx
+++ b/src/components/MomentumTabs.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import '../assets/styles/MomentumTabs.css';
 import { TAB_ANIMATION } from './projectsTabAnimation';
+import useTabAnimation, { type IndicatorBox } from '../hooks/useTabAnimation';
+import { computeIndicatorPath } from '../hooks/indicatorPath';
 
 const SHRINK_MS = TAB_ANIMATION.indicatorShrinkMs;
-const SLIDE_STRETCH_MS = TAB_ANIMATION.indicatorSlideStretchMs;
-const SLIDE_CONTRACT_MS = TAB_ANIMATION.indicatorSlideContractMs;
 const EXPAND_MS = TAB_ANIMATION.indicatorExpandMs;
 
 export type MomentumTabsProps<T extends string> = {
@@ -22,31 +22,11 @@ const MomentumTabs = <T extends string>({
     onChange,
     enabled = true
 }: MomentumTabsProps<T>) => {
-    const [indicator, setIndicator] = useState<{
-        left: number;
-        top: number;
-        width: number;
-        height: number;
-    } | null>(null);
-    const [direction, setDirection] = useState<'cw' | 'ccw'>('cw');
-    const [expanded, setExpanded] = useState(false);
-    const [retracting, setRetracting] = useState(false);
-    const [retractMode, setRetractMode] = useState<'forward' | 'reverse'>('forward');
-    // Tracks which tab the SVG is currently positioned on for animation purposes.
-    // Decoupled from `active` so that active updates immediately on click (ARIA,
-    // color), while the SVG only remounts at handoff time (after retract completes).
-    const [svgTab, setSvgTab] = useState<T>(active);
-    // True only when the perimeter trace has fully wrapped the active tab.
-    // Drives the frosted-glass tab background — appears after wrap completes,
-    // hides immediately on click while the line retracts/slides/re-wraps.
-    const [wrapComplete, setWrapComplete] = useState(false);
+    const [indicator, setIndicator] = useState<IndicatorBox | null>(null);
     const buttonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
     const initializedRef = useRef(false);
-    const expandKickedRef = useRef(false);
-    const transitionTimers = useRef<number[]>([]);
     // Set while a tab-switch or initial-wrap animation is in flight so the
     // resize listener doesn't overwrite mid-animation indicator coords.
-    const isAnimatingRef = useRef(false);
     // Fade the perimeter/underline out during resize and back in once resize
     // settles, hiding the brief jump when indicator coords snap to new layout.
     const [isResizing, setIsResizing] = useState(false);
@@ -60,16 +40,14 @@ const MomentumTabs = <T extends string>({
         activeRef.current = active;
     }, [active]);
 
-    const clearTimers = () => {
-        transitionTimers.current.forEach((id) => window.clearTimeout(id));
-        transitionTimers.current = [];
-    };
-
-    // Drain pending click-animation timers on unmount so they can't fire
-    // setState on an unmounted component.
-    useEffect(() => {
-        return () => clearTimers();
-    }, []);
+    const { animState, isAnimatingRef, handleClick: animHandleClick } = useTabAnimation(active, {
+        enabled,
+        indicator,
+        tabs,
+        buttonRefs: buttonRefs as React.MutableRefObject<Record<string, HTMLButtonElement | null>>,
+        onChange: (tab) => onChange(tab as T),
+        onIndicatorChange: setIndicator
+    });
 
     // Gated on `enabled` so we only measure once the parent signals the
     // section is in view. Important when the parent has `content-visibility: auto`
@@ -89,20 +67,6 @@ const MomentumTabs = <T extends string>({
             });
         }
     }, [enabled, active]);
-
-    // Initial wrap animation. Held until `enabled` flips to true (so the section
-    // can defer it until scrolled into view). Fires exactly once.
-    useLayoutEffect(() => {
-        if (expandKickedRef.current || !enabled || !indicator) return;
-        expandKickedRef.current = true;
-        isAnimatingRef.current = true;
-        const t = window.setTimeout(() => setExpanded(true), 80);
-        const tFrost = window.setTimeout(() => {
-            setWrapComplete(true);
-            isAnimatingRef.current = false;
-        }, 80 + EXPAND_MS);
-        transitionTimers.current.push(t, tFrost);
-    }, [enabled, indicator]);
 
     // Keep the indicator pinned to the active tab when the viewport resizes.
     // Fade out on first resize tick (gated by ref so setState fires once per
@@ -144,74 +108,10 @@ const MomentumTabs = <T extends string>({
             window.removeEventListener('resize', handleResize);
             if (settleTimer !== undefined) window.clearTimeout(settleTimer);
         };
-    }, []);
+    }, [isAnimatingRef]);
 
     const handleClick = (next: T) => {
-        if (next === active) return;
-        clearTimers();
-        isAnimatingRef.current = true;
-        const sourceEl = buttonRefs.current[active];
-        const targetEl = buttonRefs.current[next];
-        if (!sourceEl || !targetEl) return;
-
-        // Snapshot source + target measurements at click time so the animation isn't
-        // affected by the immediate `active` prop change.
-        const sourceBox = {
-            left: sourceEl.offsetLeft,
-            top: sourceEl.offsetTop,
-            width: sourceEl.offsetWidth,
-            height: sourceEl.offsetHeight
-        };
-        const targetBox = {
-            left: targetEl.offsetLeft,
-            top: targetEl.offsetTop,
-            width: targetEl.offsetWidth,
-            height: targetEl.offsetHeight
-        };
-
-        const sourceIdx = tabs.indexOf(active);
-        const targetIdx = tabs.indexOf(next);
-        const dir = targetIdx > sourceIdx ? 'cw' : 'ccw';
-        const isShift = dir !== direction;
-
-        // Notify parent immediately so ARIA + visual color update without delay.
-        onChange(next);
-        setWrapComplete(false);
-        setRetractMode(isShift ? 'reverse' : 'forward');
-        setRetracting(true);
-        setExpanded(false);
-
-        const t1 = window.setTimeout(() => {
-            const stretchLeft = Math.min(sourceBox.left, targetBox.left);
-            const stretchRight = Math.max(
-                sourceBox.left + sourceBox.width,
-                targetBox.left + targetBox.width
-            );
-            setIndicator({
-                left: stretchLeft,
-                top: sourceBox.top,
-                width: stretchRight - stretchLeft,
-                height: sourceBox.height
-            });
-        }, SHRINK_MS);
-
-        const t2 = window.setTimeout(() => {
-            setSvgTab(next);
-            setDirection(dir);
-            setRetracting(false);
-            setIndicator(targetBox);
-        }, SHRINK_MS + SLIDE_STRETCH_MS);
-
-        const t3 = window.setTimeout(() => {
-            setExpanded(true);
-        }, SHRINK_MS + SLIDE_STRETCH_MS + SLIDE_CONTRACT_MS);
-
-        const t4 = window.setTimeout(() => {
-            setWrapComplete(true);
-            isAnimatingRef.current = false;
-        }, SHRINK_MS + SLIDE_STRETCH_MS + SLIDE_CONTRACT_MS + EXPAND_MS);
-
-        transitionTimers.current.push(t1, t2, t3, t4);
+        animHandleClick(next, active);
     };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
@@ -237,15 +137,15 @@ const MomentumTabs = <T extends string>({
 
     const width = indicator?.width ?? 0;
     const height = indicator?.height ?? 0;
-    const sideLength = 2 * height + width;
-    const pathD =
-        direction === 'cw'
-            ? `M ${width} ${height} L ${width} 0 L 0 0 L 0 ${height}`
-            : `M 0 ${height} L 0 0 L ${width} 0 L ${width} ${height}`;
-    const dashArray = expanded
-        ? `${sideLength} 0`
-        : `0 ${Math.max(sideLength, 1)}`;
-    const dashOffset = retracting && retractMode === 'forward' ? -sideLength : 0;
+
+    const { pathD, dashArray, dashOffset } = computeIndicatorPath({
+        width,
+        height,
+        direction: animState.direction,
+        expanded: animState.expanded,
+        retracting: animState.retracting,
+        retractMode: animState.retractMode
+    });
 
     return (
         <div className="momentum-tabs" role="tablist">
@@ -261,7 +161,7 @@ const MomentumTabs = <T extends string>({
                     onClick={() => handleClick(tab)}
                     onKeyDown={handleKeyDown}
                     className={`momentum-tab ${active === tab ? 'is-active' : ''} ${
-                        active === tab && wrapComplete ? 'is-frosted' : ''
+                        active === tab && animState.wrapComplete ? 'is-frosted' : ''
                     }`}
                 >
                     {tab} Projects
@@ -279,7 +179,7 @@ const MomentumTabs = <T extends string>({
                         }}
                     />
                     <svg
-                        key={`${svgTab}-${direction}`}
+                        key={`${animState.svgTab}-${animState.direction}`}
                         aria-hidden
                         className={`momentum-tabs__perimeter ${isResizing ? 'is-resizing' : ''}`}
                         style={{
@@ -306,9 +206,9 @@ const MomentumTabs = <T extends string>({
                                 strokeDasharray: dashArray,
                                 strokeDashoffset: dashOffset,
                                 transition: `stroke-dasharray ${
-                                    expanded ? EXPAND_MS : SHRINK_MS
+                                    animState.expanded ? EXPAND_MS : SHRINK_MS
                                 }ms cubic-bezier(0.4, 0, 0.2, 1), stroke-dashoffset ${
-                                    expanded ? EXPAND_MS : SHRINK_MS
+                                    animState.expanded ? EXPAND_MS : SHRINK_MS
                                 }ms cubic-bezier(0.4, 0, 0.2, 1)`
                             }}
                         />

--- a/src/hooks/indicatorPath.test.ts
+++ b/src/hooks/indicatorPath.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'vitest';
+import { computeIndicatorPath, type IndicatorPathInput } from './indicatorPath';
+
+const base: IndicatorPathInput = {
+    width: 120,
+    height: 40,
+    direction: 'cw',
+    expanded: false,
+    retracting: false,
+    retractMode: 'forward'
+};
+
+describe('computeIndicatorPath — pathD', () => {
+    test('cw direction traces from bottom-right over the top', () => {
+        const { pathD } = computeIndicatorPath(base);
+        // cw: start bottom-right (width, height) → top-right → top-left → bottom-left
+        expect(pathD).toBe('M 120 40 L 120 0 L 0 0 L 0 40');
+    });
+
+    test('ccw direction traces from bottom-left over the top', () => {
+        const { pathD } = computeIndicatorPath({ ...base, direction: 'ccw' });
+        expect(pathD).toBe('M 0 40 L 0 0 L 120 0 L 120 40');
+    });
+
+    test('pathD updates when dimensions change', () => {
+        const { pathD } = computeIndicatorPath({ ...base, width: 80, height: 30 });
+        expect(pathD).toBe('M 80 30 L 80 0 L 0 0 L 0 30');
+    });
+});
+
+describe('computeIndicatorPath — dashArray', () => {
+    test('collapsed: dashArray is "0 <sideLength>" (trace hidden)', () => {
+        // sideLength = 2*40 + 120 = 200
+        const { dashArray } = computeIndicatorPath({ ...base, expanded: false });
+        expect(dashArray).toBe('0 200');
+    });
+
+    test('expanded: dashArray is "<sideLength> 0" (trace fully drawn)', () => {
+        const { dashArray } = computeIndicatorPath({ ...base, expanded: true });
+        expect(dashArray).toBe('200 0');
+    });
+
+    test('collapsed with near-zero dimensions uses at least 1 for the gap to avoid degenerate SVG', () => {
+        const { dashArray } = computeIndicatorPath({ ...base, width: 0, height: 0 });
+        // sideLength = 0, Math.max(0, 1) = 1
+        expect(dashArray).toBe('0 1');
+    });
+
+    test('dashArray reflects computed sideLength: 2*height + width', () => {
+        const { dashArray } = computeIndicatorPath({ ...base, width: 200, height: 50, expanded: true });
+        // sideLength = 2*50 + 200 = 300
+        expect(dashArray).toBe('300 0');
+    });
+});
+
+describe('computeIndicatorPath — dashOffset', () => {
+    test('not retracting: dashOffset is 0', () => {
+        const { dashOffset } = computeIndicatorPath({ ...base, retracting: false });
+        expect(dashOffset).toBe(0);
+    });
+
+    test('retracting in forward mode: dashOffset is -sideLength (trace retracts away)', () => {
+        // sideLength = 2*40 + 120 = 200
+        const { dashOffset } = computeIndicatorPath({
+            ...base,
+            retracting: true,
+            retractMode: 'forward'
+        });
+        expect(dashOffset).toBe(-200);
+    });
+
+    test('retracting in reverse mode: dashOffset is 0 (reverse retract uses dashArray instead)', () => {
+        const { dashOffset } = computeIndicatorPath({
+            ...base,
+            retracting: true,
+            retractMode: 'reverse'
+        });
+        expect(dashOffset).toBe(0);
+    });
+
+    test('expanded + retracting (mid-interrupt): dashOffset still computed by retractMode', () => {
+        const { dashOffset } = computeIndicatorPath({
+            ...base,
+            expanded: true,
+            retracting: true,
+            retractMode: 'forward'
+        });
+        expect(dashOffset).toBe(-200);
+    });
+});
+
+describe('computeIndicatorPath — composite scenarios', () => {
+    test('initial idle state: not expanded, not retracting, dashOffset 0', () => {
+        const result = computeIndicatorPath(base);
+        expect(result.dashOffset).toBe(0);
+        expect(result.dashArray).toBe('0 200');
+        expect(result.pathD).toBe('M 120 40 L 120 0 L 0 0 L 0 40');
+    });
+
+    test('fully wrapped state: expanded true, not retracting', () => {
+        const result = computeIndicatorPath({ ...base, expanded: true });
+        expect(result.dashArray).toBe('200 0');
+        expect(result.dashOffset).toBe(0);
+    });
+
+    test('mid-retract: retracting forward, not expanded', () => {
+        const result = computeIndicatorPath({
+            ...base,
+            retracting: true,
+            retractMode: 'forward',
+            expanded: false
+        });
+        // sideLength = 200; offset = -200; dashArray shows gap
+        expect(result.dashOffset).toBe(-200);
+        expect(result.dashArray).toBe('0 200');
+    });
+});

--- a/src/hooks/indicatorPath.ts
+++ b/src/hooks/indicatorPath.ts
@@ -1,0 +1,60 @@
+// Pure-function SVG path math for the MomentumTabs perimeter indicator.
+// No state, no effects — computes geometry from the current animation state.
+//
+// The perimeter trace draws along the top and two sides of the indicator box.
+// The path starts at the bottom edge and traces up-and-over, so the
+// stroke-dasharray trick can animate it growing from nothing to the full
+// perimeter.
+//
+// `direction` controls which corner the trace starts at:
+//   'cw'  — starts bottom-right, traces: right-side up → top → left-side down
+//   'ccw' — starts bottom-left,  traces: left-side up  → top → right-side down
+
+export type IndicatorDirection = 'cw' | 'ccw';
+
+export type IndicatorPathInput = {
+    width: number;
+    height: number;
+    direction: IndicatorDirection;
+    expanded: boolean;
+    retracting: boolean;
+    retractMode: 'forward' | 'reverse';
+};
+
+export type IndicatorPathOutput = {
+    /** SVG `d` attribute for the perimeter path. */
+    pathD: string;
+    /** Value for `stroke-dasharray` CSS property (e.g. `"740 0"` or `"0 741"`). */
+    dashArray: string;
+    /** Value for `stroke-dashoffset` CSS property. */
+    dashOffset: number;
+};
+
+/**
+ * Compute the SVG path geometry for the MomentumTabs perimeter indicator.
+ *
+ * The path traces three sides of the indicator box (top + two vertical sides).
+ * `sideLength = 2 * height + width` is the total perimeter of those three sides.
+ *
+ * - `expanded = true`  → dashArray = `"${sideLength} 0"`  (fully drawn)
+ * - `expanded = false` → dashArray = `"0 ${sideLength}"`  (hidden)
+ * - `retracting + forward` mode → dashOffset = `-sideLength` (retracts away)
+ */
+export function computeIndicatorPath(input: IndicatorPathInput): IndicatorPathOutput {
+    const { width, height, direction, expanded, retracting, retractMode } = input;
+
+    const sideLength = 2 * height + width;
+
+    const pathD =
+        direction === 'cw'
+            ? `M ${width} ${height} L ${width} 0 L 0 0 L 0 ${height}`
+            : `M 0 ${height} L 0 0 L ${width} 0 L ${width} ${height}`;
+
+    const dashArray = expanded
+        ? `${sideLength} 0`
+        : `0 ${Math.max(sideLength, 1)}`;
+
+    const dashOffset = retracting && retractMode === 'forward' ? -sideLength : 0;
+
+    return { pathD, dashArray, dashOffset };
+}

--- a/src/hooks/useTabAnimation.test.ts
+++ b/src/hooks/useTabAnimation.test.ts
@@ -1,0 +1,352 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+import useTabAnimation, { type UseTabAnimationOptions, type IndicatorBox } from './useTabAnimation';
+import { TAB_ANIMATION } from '../components/projectsTabAnimation';
+
+const SHRINK_MS = TAB_ANIMATION.indicatorShrinkMs;
+const SLIDE_STRETCH_MS = TAB_ANIMATION.indicatorSlideStretchMs;
+const SLIDE_CONTRACT_MS = TAB_ANIMATION.indicatorSlideContractMs;
+const EXPAND_MS = TAB_ANIMATION.indicatorExpandMs;
+
+const TABS = ['Client', 'Featured', 'Personal'] as const;
+
+// Box geometry helpers
+const makeBox = (left: number): IndicatorBox => ({ left, top: 0, width: 100, height: 40 });
+
+// Create a DOM button stub that reports offsetLeft etc. (jsdom doesn't do layout,
+// so we manually assign the properties to simulate measured DOM elements).
+function makeButtonEl(left: number, width = 100): HTMLButtonElement {
+    const el = document.createElement('button');
+    Object.defineProperty(el, 'offsetLeft', { value: left, configurable: true });
+    Object.defineProperty(el, 'offsetTop', { value: 0, configurable: true });
+    Object.defineProperty(el, 'offsetWidth', { value: width, configurable: true });
+    Object.defineProperty(el, 'offsetHeight', { value: 40, configurable: true });
+    return el;
+}
+
+function makeButtonRefs(): React.MutableRefObject<Record<string, HTMLButtonElement | null>> {
+    return {
+        current: {
+            Client: makeButtonEl(0),
+            Featured: makeButtonEl(110),
+            Personal: makeButtonEl(220)
+        }
+    };
+}
+
+function makeOptions(
+    overrides: Partial<UseTabAnimationOptions> = {}
+): UseTabAnimationOptions {
+    const onChange = vi.fn();
+    const onIndicatorChange = vi.fn();
+    return {
+        enabled: true,
+        indicator: makeBox(110),
+        tabs: TABS,
+        buttonRefs: makeButtonRefs(),
+        onChange,
+        onIndicatorChange,
+        ...overrides
+    };
+}
+
+beforeEach(() => {
+    vi.useFakeTimers();
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+});
+
+// ── Initial state ─────────────────────────────────────────────────────────────
+
+describe('useTabAnimation — initial state', () => {
+    test('svgTab matches the initial activeTab', () => {
+        const { result } = renderHook(() =>
+            useTabAnimation('Featured', makeOptions())
+        );
+        expect(result.current.animState.svgTab).toBe('Featured');
+    });
+
+    test('expanded is false before the initial-wrap timers fire', () => {
+        const { result } = renderHook(() =>
+            useTabAnimation('Featured', makeOptions())
+        );
+        // 80ms initial wrap timer has not fired yet
+        expect(result.current.animState.expanded).toBe(false);
+    });
+
+    test('wrapComplete is false before the initial-wrap completes', () => {
+        const { result } = renderHook(() =>
+            useTabAnimation('Featured', makeOptions())
+        );
+        expect(result.current.animState.wrapComplete).toBe(false);
+    });
+
+    test('isAnimatingRef is true immediately after mount (initial wrap in flight)', () => {
+        const { result } = renderHook(() =>
+            useTabAnimation('Featured', makeOptions())
+        );
+        expect(result.current.isAnimatingRef.current).toBe(true);
+    });
+});
+
+// ── Initial wrap animation ────────────────────────────────────────────────────
+
+describe('useTabAnimation — initial wrap animation', () => {
+    test('expanded becomes true after 80ms', () => {
+        const { result } = renderHook(() =>
+            useTabAnimation('Featured', makeOptions())
+        );
+        act(() => { vi.advanceTimersByTime(80); });
+        expect(result.current.animState.expanded).toBe(true);
+    });
+
+    test('wrapComplete becomes true after 80 + EXPAND_MS', () => {
+        const { result } = renderHook(() =>
+            useTabAnimation('Featured', makeOptions())
+        );
+        act(() => { vi.advanceTimersByTime(80 + EXPAND_MS); });
+        expect(result.current.animState.wrapComplete).toBe(true);
+    });
+
+    test('isAnimatingRef resets to false after wrap completes', () => {
+        const { result } = renderHook(() =>
+            useTabAnimation('Featured', makeOptions())
+        );
+        act(() => { vi.advanceTimersByTime(80 + EXPAND_MS); });
+        expect(result.current.isAnimatingRef.current).toBe(false);
+    });
+
+    test('initial wrap does NOT fire when enabled is false', () => {
+        const { result } = renderHook(() =>
+            useTabAnimation('Featured', makeOptions({ enabled: false }))
+        );
+        act(() => { vi.advanceTimersByTime(80 + EXPAND_MS + 100); });
+        expect(result.current.animState.expanded).toBe(false);
+        expect(result.current.animState.wrapComplete).toBe(false);
+    });
+
+    test('initial wrap does NOT fire when indicator is null', () => {
+        const { result } = renderHook(() =>
+            useTabAnimation('Featured', makeOptions({ indicator: null }))
+        );
+        act(() => { vi.advanceTimersByTime(80 + EXPAND_MS + 100); });
+        expect(result.current.animState.expanded).toBe(false);
+    });
+});
+
+// ── Tab switch: direction ─────────────────────────────────────────────────────
+
+describe('useTabAnimation — direction inference', () => {
+    test('clicking a later-indexed tab sets direction cw', () => {
+        const opts = makeOptions();
+        const { result } = renderHook(() =>
+            useTabAnimation('Featured', opts)
+        );
+        // Let initial wrap complete first
+        act(() => { vi.advanceTimersByTime(80 + EXPAND_MS); });
+
+        act(() => { result.current.handleClick('Personal', 'Featured'); });
+        // direction flips in t2 (after SHRINK + SLIDE_STRETCH)
+        act(() => { vi.advanceTimersByTime(SHRINK_MS + SLIDE_STRETCH_MS); });
+        expect(result.current.animState.direction).toBe('cw');
+    });
+
+    test('clicking an earlier-indexed tab sets direction ccw', () => {
+        const opts = makeOptions();
+        const { result } = renderHook(() =>
+            useTabAnimation('Featured', opts)
+        );
+        act(() => { vi.advanceTimersByTime(80 + EXPAND_MS); });
+
+        act(() => { result.current.handleClick('Client', 'Featured'); });
+        act(() => { vi.advanceTimersByTime(SHRINK_MS + SLIDE_STRETCH_MS); });
+        expect(result.current.animState.direction).toBe('ccw');
+    });
+});
+
+// ── Tab switch: phase transitions ─────────────────────────────────────────────
+
+describe('useTabAnimation — tab switch phase sequence', () => {
+    test('handleClick immediately sets retracting=true and wrapComplete=false', () => {
+        const opts = makeOptions();
+        const { result } = renderHook(() =>
+            useTabAnimation('Featured', opts)
+        );
+        act(() => { vi.advanceTimersByTime(80 + EXPAND_MS); }); // let wrap complete
+
+        act(() => { result.current.handleClick('Personal', 'Featured'); });
+        expect(result.current.animState.retracting).toBe(true);
+        expect(result.current.animState.wrapComplete).toBe(false);
+        expect(result.current.animState.expanded).toBe(false);
+    });
+
+    test('after SHRINK_MS: onIndicatorChange called with stretched box', () => {
+        const opts = makeOptions();
+        const { result } = renderHook(() =>
+            useTabAnimation('Featured', opts)
+        );
+        act(() => { vi.advanceTimersByTime(80 + EXPAND_MS); });
+
+        act(() => { result.current.handleClick('Personal', 'Featured'); });
+        act(() => { vi.advanceTimersByTime(SHRINK_MS); });
+
+        // Featured is at left=110, Personal is at left=220. stretchLeft=110, stretchRight=320 → width=210
+        expect(opts.onIndicatorChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({ left: 110, width: 210 })
+        );
+    });
+
+    test('after SHRINK + SLIDE_STRETCH: svgTab updates to target tab', () => {
+        const opts = makeOptions();
+        const { result } = renderHook(() =>
+            useTabAnimation('Featured', opts)
+        );
+        act(() => { vi.advanceTimersByTime(80 + EXPAND_MS); });
+
+        act(() => { result.current.handleClick('Personal', 'Featured'); });
+        act(() => { vi.advanceTimersByTime(SHRINK_MS + SLIDE_STRETCH_MS); });
+
+        expect(result.current.animState.svgTab).toBe('Personal');
+        expect(result.current.animState.retracting).toBe(false);
+    });
+
+    test('after SHRINK + SLIDE_STRETCH + SLIDE_CONTRACT: expanded becomes true', () => {
+        const opts = makeOptions();
+        const { result } = renderHook(() =>
+            useTabAnimation('Featured', opts)
+        );
+        act(() => { vi.advanceTimersByTime(80 + EXPAND_MS); });
+
+        act(() => { result.current.handleClick('Personal', 'Featured'); });
+        act(() => { vi.advanceTimersByTime(SHRINK_MS + SLIDE_STRETCH_MS + SLIDE_CONTRACT_MS); });
+
+        expect(result.current.animState.expanded).toBe(true);
+    });
+
+    test('after full animation sequence: wrapComplete=true and isAnimating=false', () => {
+        const opts = makeOptions();
+        const { result } = renderHook(() =>
+            useTabAnimation('Featured', opts)
+        );
+        act(() => { vi.advanceTimersByTime(80 + EXPAND_MS); });
+
+        act(() => { result.current.handleClick('Personal', 'Featured'); });
+        const totalMs = SHRINK_MS + SLIDE_STRETCH_MS + SLIDE_CONTRACT_MS + EXPAND_MS;
+        act(() => { vi.advanceTimersByTime(totalMs); });
+
+        expect(result.current.animState.wrapComplete).toBe(true);
+        expect(result.current.isAnimatingRef.current).toBe(false);
+    });
+
+    test('onChange is called immediately with the new tab', () => {
+        const opts = makeOptions();
+        const { result } = renderHook(() =>
+            useTabAnimation('Featured', opts)
+        );
+        act(() => { vi.advanceTimersByTime(80 + EXPAND_MS); });
+
+        act(() => { result.current.handleClick('Personal', 'Featured'); });
+        expect(opts.onChange).toHaveBeenCalledWith('Personal');
+    });
+});
+
+// ── Rapid clicks — interrupt safety ──────────────────────────────────────────
+
+describe('useTabAnimation — rapid click interrupt', () => {
+    test('second click before first completes does not leak timers (no setState after cleared)', () => {
+        const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout');
+        const opts = makeOptions();
+        const { result } = renderHook(() =>
+            useTabAnimation('Featured', opts)
+        );
+        act(() => { vi.advanceTimersByTime(80 + EXPAND_MS); });
+
+        // First click
+        act(() => { result.current.handleClick('Personal', 'Featured'); });
+        // Interrupt before any phase completes
+        act(() => { vi.advanceTimersByTime(SHRINK_MS - 10); });
+        // Second click interrupts the first
+        act(() => { result.current.handleClick('Client', 'Personal'); });
+
+        // clearTimeout should have been called (at least once for the interrupt)
+        expect(clearTimeoutSpy).toHaveBeenCalled();
+
+        // Advance to well past first click's completion — should not throw or cause unexpected state
+        act(() => { vi.advanceTimersByTime(SHRINK_MS + SLIDE_STRETCH_MS + SLIDE_CONTRACT_MS + EXPAND_MS + 500); });
+        // svgTab should reflect the second click's target at handoff time
+        expect(result.current.animState.svgTab).toBe('Client');
+    });
+
+    test('handleClick is a no-op when next === active', () => {
+        const opts = makeOptions();
+        const { result } = renderHook(() =>
+            useTabAnimation('Featured', opts)
+        );
+        act(() => { vi.advanceTimersByTime(80 + EXPAND_MS); });
+
+        act(() => { result.current.handleClick('Featured', 'Featured'); });
+        expect(opts.onChange).not.toHaveBeenCalled();
+        expect(result.current.animState.retracting).toBe(false);
+    });
+});
+
+// ── Cleanup on unmount ────────────────────────────────────────────────────────
+
+describe('useTabAnimation — unmount cleanup', () => {
+    test('pending timers are cleared on unmount (no setState after unmount)', () => {
+        const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout');
+        const opts = makeOptions();
+        const { result, unmount } = renderHook(() =>
+            useTabAnimation('Featured', opts)
+        );
+        act(() => { vi.advanceTimersByTime(80 + EXPAND_MS); });
+
+        // Start a transition
+        act(() => { result.current.handleClick('Personal', 'Featured'); });
+
+        // Unmount mid-transition — should clear all pending timers
+        act(() => { unmount(); });
+
+        expect(clearTimeoutSpy).toHaveBeenCalled();
+
+        // Advance past where timers would have fired — no React warning expected
+        act(() => { vi.advanceTimersByTime(SHRINK_MS + SLIDE_STRETCH_MS + SLIDE_CONTRACT_MS + EXPAND_MS + 500); });
+    });
+});
+
+// ── retractMode ───────────────────────────────────────────────────────────────
+
+describe('useTabAnimation — retractMode', () => {
+    test('same-direction click uses forward retract mode', () => {
+        // Default direction is 'cw'; clicking forward (cw) should stay 'forward'
+        const opts = makeOptions();
+        const { result } = renderHook(() =>
+            useTabAnimation('Client', opts)
+        );
+        act(() => { vi.advanceTimersByTime(80 + EXPAND_MS); });
+
+        // Client → Featured is cw (index 0 → 1). Default direction is 'cw' → no shift.
+        act(() => { result.current.handleClick('Featured', 'Client'); });
+        expect(result.current.animState.retractMode).toBe('forward');
+    });
+
+    test('direction-shift click uses reverse retract mode', () => {
+        const opts = makeOptions();
+        const { result } = renderHook(() =>
+            useTabAnimation('Client', opts)
+        );
+        act(() => { vi.advanceTimersByTime(80 + EXPAND_MS); });
+
+        // Client → Featured is cw (sets direction to cw).
+        act(() => { result.current.handleClick('Featured', 'Client'); });
+        act(() => { vi.advanceTimersByTime(SHRINK_MS + SLIDE_STRETCH_MS + SLIDE_CONTRACT_MS + EXPAND_MS); });
+
+        // Now going Featured → Client is ccw — shifts direction → reverse mode.
+        act(() => { result.current.handleClick('Client', 'Featured'); });
+        expect(result.current.animState.retractMode).toBe('reverse');
+    });
+});

--- a/src/hooks/useTabAnimation.ts
+++ b/src/hooks/useTabAnimation.ts
@@ -1,0 +1,189 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { TAB_ANIMATION } from '../components/projectsTabAnimation';
+
+const SHRINK_MS = TAB_ANIMATION.indicatorShrinkMs;
+const SLIDE_STRETCH_MS = TAB_ANIMATION.indicatorSlideStretchMs;
+const SLIDE_CONTRACT_MS = TAB_ANIMATION.indicatorSlideContractMs;
+const EXPAND_MS = TAB_ANIMATION.indicatorExpandMs;
+
+export type TabAnimationState = {
+    /** Which tab the SVG is currently positioned on. Lags `activeTab` during
+     *  a transition — the SVG only remounts at handoff time (after retract). */
+    svgTab: string;
+    /** Direction the perimeter trace draws. 'cw' = clockwise (forward/right). */
+    direction: 'cw' | 'ccw';
+    /** True while the perimeter trace is fully expanded around the active tab. */
+    expanded: boolean;
+    /** True while the perimeter trace is retracting (shrinking off old tab). */
+    retracting: boolean;
+    /** Controls whether the retract moves forward (offset trick) or reverse (dashArray). */
+    retractMode: 'forward' | 'reverse';
+    /** True only when the perimeter has fully wrapped. Drives the frosted-glass bg. */
+    wrapComplete: boolean;
+};
+
+export type IndicatorBox = {
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+};
+
+export type UseTabAnimationOptions = {
+    /** When false, the initial wrap animation is held until this becomes true. */
+    enabled?: boolean;
+    /** The initial indicator box (measured by the consumer on mount). */
+    indicator: IndicatorBox | null;
+    /** The tab labels in order — used to compute direction (forward / backward). */
+    tabs: readonly string[];
+    /** DOM button refs keyed by tab label, for snapshotting layout at click time. */
+    buttonRefs: React.MutableRefObject<Record<string, HTMLButtonElement | null>>;
+    /** Called when a tab switch should be committed to the parent. */
+    onChange: (tab: string) => void;
+    /** Called by the hook when indicator coords should be updated. */
+    onIndicatorChange: (box: IndicatorBox) => void;
+};
+
+export type UseTabAnimationReturn = {
+    animState: TabAnimationState;
+    /** True while a tab-switch or initial-wrap animation is in flight.
+     *  Used by the resize handler to avoid overwriting mid-animation coords. */
+    isAnimatingRef: React.MutableRefObject<boolean>;
+    handleClick: (next: string, active: string) => void;
+};
+
+/**
+ * Manages the chained-setTimeout choreography that drives the MomentumTabs
+ * perimeter trace animation:
+ *
+ *   click → retract (shrink off old tab) →
+ *   slide-stretch (indicator expands to span both tabs) →
+ *   slide-contract (indicator snaps to new tab) →
+ *   expand (perimeter traces around new tab) →
+ *   idle
+ *
+ * Timer cleanup is guaranteed on unmount and on rapid re-clicks (interrupt safety).
+ */
+function useTabAnimation(
+    activeTab: string,
+    options: UseTabAnimationOptions
+): UseTabAnimationReturn {
+    const { enabled = true, indicator, tabs, buttonRefs, onChange, onIndicatorChange } = options;
+
+    const [svgTab, setSvgTab] = useState<string>(activeTab);
+    const [direction, setDirection] = useState<'cw' | 'ccw'>('cw');
+    const [expanded, setExpanded] = useState(false);
+    const [retracting, setRetracting] = useState(false);
+    const [retractMode, setRetractMode] = useState<'forward' | 'reverse'>('forward');
+    const [wrapComplete, setWrapComplete] = useState(false);
+
+    const expandKickedRef = useRef(false);
+    const transitionTimers = useRef<number[]>([]);
+    const isAnimatingRef = useRef(false);
+
+    const clearTimers = () => {
+        transitionTimers.current.forEach((id) => window.clearTimeout(id));
+        transitionTimers.current = [];
+    };
+
+    // Drain pending timers on unmount so they can't fire setState on an
+    // unmounted component.
+    useEffect(() => {
+        return () => clearTimers();
+    }, []);
+
+    // Initial wrap animation. Held until `enabled` flips true and the
+    // indicator box is measured. Fires exactly once.
+    useLayoutEffect(() => {
+        if (expandKickedRef.current || !enabled || !indicator) return;
+        expandKickedRef.current = true;
+        isAnimatingRef.current = true;
+        const t = window.setTimeout(() => setExpanded(true), 80);
+        const tFrost = window.setTimeout(() => {
+            setWrapComplete(true);
+            isAnimatingRef.current = false;
+        }, 80 + EXPAND_MS);
+        transitionTimers.current.push(t, tFrost);
+    }, [enabled, indicator]);
+
+    const handleClick = (next: string, active: string) => {
+        if (next === active) return;
+        clearTimers();
+        isAnimatingRef.current = true;
+
+        const sourceEl = buttonRefs.current[active];
+        const targetEl = buttonRefs.current[next];
+        if (!sourceEl || !targetEl) return;
+
+        // Snapshot layout at click time — measurements are unaffected by the
+        // immediate `active` prop change that follows.
+        const sourceBox: IndicatorBox = {
+            left: sourceEl.offsetLeft,
+            top: sourceEl.offsetTop,
+            width: sourceEl.offsetWidth,
+            height: sourceEl.offsetHeight
+        };
+        const targetBox: IndicatorBox = {
+            left: targetEl.offsetLeft,
+            top: targetEl.offsetTop,
+            width: targetEl.offsetWidth,
+            height: targetEl.offsetHeight
+        };
+
+        const sourceIdx = tabs.indexOf(active);
+        const targetIdx = tabs.indexOf(next);
+        const dir: 'cw' | 'ccw' = targetIdx > sourceIdx ? 'cw' : 'ccw';
+        const isShift = dir !== direction;
+
+        // Notify parent immediately — ARIA + visual color update without delay.
+        onChange(next);
+        setWrapComplete(false);
+        setRetractMode(isShift ? 'reverse' : 'forward');
+        setRetracting(true);
+        setExpanded(false);
+
+        // Phase 1: indicator shrinks off the old tab (SHRINK_MS)
+        const t1 = window.setTimeout(() => {
+            const stretchLeft = Math.min(sourceBox.left, targetBox.left);
+            const stretchRight = Math.max(
+                sourceBox.left + sourceBox.width,
+                targetBox.left + targetBox.width
+            );
+            onIndicatorChange({
+                left: stretchLeft,
+                top: sourceBox.top,
+                width: stretchRight - stretchLeft,
+                height: sourceBox.height
+            });
+        }, SHRINK_MS);
+
+        // Phase 2: indicator slides + contracts (SHRINK_MS + SLIDE_STRETCH_MS)
+        const t2 = window.setTimeout(() => {
+            setSvgTab(next);
+            setDirection(dir);
+            setRetracting(false);
+            onIndicatorChange(targetBox);
+        }, SHRINK_MS + SLIDE_STRETCH_MS);
+
+        // Phase 3: perimeter starts expanding around new tab
+        const t3 = window.setTimeout(() => {
+            setExpanded(true);
+        }, SHRINK_MS + SLIDE_STRETCH_MS + SLIDE_CONTRACT_MS);
+
+        // Phase 4: expansion complete → wrap done, animation idle
+        const t4 = window.setTimeout(() => {
+            setWrapComplete(true);
+            isAnimatingRef.current = false;
+        }, SHRINK_MS + SLIDE_STRETCH_MS + SLIDE_CONTRACT_MS + EXPAND_MS);
+
+        transitionTimers.current.push(t1, t2, t3, t4);
+    };
+
+    return {
+        animState: { svgTab, direction, expanded, retracting, retractMode, wrapComplete },
+        isAnimatingRef,
+        handleClick
+    };
+}
+
+export default useTabAnimation;


### PR DESCRIPTION
## Summary

- Extracts `useTabAnimation` hook (`src/hooks/useTabAnimation.ts`) — lifts the chained-setTimeout choreography (retract → slide-stretch → slide-contract → expand → idle) and all animation state out of MomentumTabs
- Extracts `computeIndicatorPath` pure module (`src/hooks/indicatorPath.ts`) — the SVG `pathD`/`dashArray`/`dashOffset` geometry math, following the `projectsTabAnimation.ts` pattern
- `MomentumTabs.tsx` shrinks 321 → 222 lines, retaining only layout measurement, resize handling, keyboard nav, and rendering

## Test plan

- [ ] `npx tsc --noEmit` — clean (verified)
- [ ] `npm run lint` — clean (verified)
- [ ] `npm test` — 183/183 passing, 0 regressions (36 pre-existing + 36 new unit tests)
- [ ] `npm run build` — bundle clean, no size growth (verified)
- [ ] Storybook stories unchanged — `Default`, `Playground`, `LongLabels`, `TwoTabs`, `ClickedThroughTabs`, `KeyboardNavigated` all pass in Chromatic