### PR TITLE
refactor(slider): Phase 3.3 — FeaturedImageSlider split (319 → 203 lines)

### DIFF
--- a/src/components/FeaturedImageSlider.tsx
+++ b/src/components/FeaturedImageSlider.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import SliderArrowButton from './SliderArrowButton';
 import ResponsiveImage from './ResponsiveImage';
+import SliderFrostedDots from './SliderFrostedDots';
+import SliderOutlinedDots from './SliderOutlinedDots';
+import SliderSegmentedProgress from './SliderSegmentedProgress';
+import SliderCounterIndicator from './SliderCounterIndicator';
+import LightboxOverlay from './LightboxOverlay';
 import '../assets/styles/FeaturedImageSlider.css';
 
 export type FeaturedImageSlide = {
@@ -158,30 +162,6 @@ const FeaturedImageSlider = ({
         else setLightboxOpen(true);
     };
 
-    const dotIndicator = (variant: 'frosted' | 'outlined') => (
-        <div
-            className={`featured-image-slider__dots featured-image-slider__dots--${variant}`}
-            role="tablist"
-        >
-            {images.map((img, i) => (
-                <button
-                    key={img.src}
-                    type="button"
-                    role="tab"
-                    aria-label={`Show image ${i + 1}`}
-                    aria-selected={i === index}
-                    className={`featured-image-slider__dot ${
-                        i === index ? 'is-active' : ''
-                    }`}
-                    onClick={(e) => {
-                        e.stopPropagation();
-                        setIndex(i);
-                    }}
-                />
-            ))}
-        </div>
-    );
-
     // index is always valid — it's clamped to [0, images.length-1] by setIndex.
     const activeSlide = images[index]!;
 
@@ -230,87 +210,45 @@ const FeaturedImageSlider = ({
             )}
 
             {indicator === 'segmented-progress' && images.length > 1 && (
-                <div className="featured-image-slider__segments" role="tablist">
-                    {images.map((img, i) => {
-                        const fill =
-                            i < index ? 1 : i === index ? progress : 0;
-                        return (
-                            <button
-                                key={img.src}
-                                type="button"
-                                role="tab"
-                                aria-label={`Show image ${i + 1}`}
-                                aria-selected={i === index}
-                                className="featured-image-slider__segment"
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                    setIndex(i);
-                                }}
-                            >
-                                <span
-                                    className="featured-image-slider__segment-fill"
-                                    style={{ width: `${fill * 100}%` }}
-                                />
-                            </button>
-                        );
-                    })}
-                </div>
+                <SliderSegmentedProgress
+                    images={images}
+                    currentIndex={index}
+                    progress={progress}
+                    onSelect={setIndex}
+                />
             )}
 
             {indicator === 'counter' && images.length > 1 && (
-                <div
-                    className="featured-image-slider__counter"
-                    aria-live="polite"
-                >
-                    {index + 1} / {images.length}
-                </div>
+                <SliderCounterIndicator
+                    currentIndex={index}
+                    totalSlides={images.length}
+                />
             )}
 
-            {indicator === 'frosted-dots' && images.length > 1 && dotIndicator('frosted')}
-            {indicator === 'outlined-dots' && images.length > 1 && dotIndicator('outlined')}
+            {indicator === 'frosted-dots' && images.length > 1 && (
+                <SliderFrostedDots
+                    images={images}
+                    currentIndex={index}
+                    onSelect={setIndex}
+                />
+            )}
 
-            {lightboxOpen && createPortal(
-                <div
-                    className="featured-image-slider__lightbox"
-                    role="dialog"
-                    aria-modal="true"
-                    aria-label={activeSlide.alt}
-                    onClick={() => setLightboxOpen(false)}
-                >
-                    <ResponsiveImage
-                        src={activeSlide.src}
-                        srcWebp={activeSlide.srcWebp}
-                        alt={activeSlide.alt}
-                        className="featured-image-slider__lightbox-img"
-                        onClick={(e) => e.stopPropagation()}
-                    />
-                    <button
-                        type="button"
-                        aria-label="Close"
-                        className="featured-image-slider__lightbox-close"
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            setLightboxOpen(false);
-                        }}
-                    >
-                        ×
-                    </button>
-                    {images.length > 1 && (
-                        <>
-                            <SliderArrowButton
-                                direction="prev"
-                                classScope="featured-image-slider__lightbox-arrow"
-                                onClick={prev}
-                            />
-                            <SliderArrowButton
-                                direction="next"
-                                classScope="featured-image-slider__lightbox-arrow"
-                                onClick={next}
-                            />
-                        </>
-                    )}
-                </div>,
-                document.body
+            {indicator === 'outlined-dots' && images.length > 1 && (
+                <SliderOutlinedDots
+                    images={images}
+                    currentIndex={index}
+                    onSelect={setIndex}
+                />
+            )}
+
+            {lightboxOpen && (
+                <LightboxOverlay
+                    images={images}
+                    activeSlide={activeSlide}
+                    onClose={() => setLightboxOpen(false)}
+                    onPrev={prev}
+                    onNext={next}
+                />
             )}
         </div>
     );

--- a/src/components/FeaturedImageSlider.tsx
+++ b/src/components/FeaturedImageSlider.tsx
@@ -6,6 +6,7 @@ import SliderOutlinedDots from './SliderOutlinedDots';
 import SliderSegmentedProgress from './SliderSegmentedProgress';
 import SliderCounterIndicator from './SliderCounterIndicator';
 import LightboxOverlay from './LightboxOverlay';
+import useCarouselAutoplay from '../hooks/useCarouselAutoplay';
 import '../assets/styles/FeaturedImageSlider.css';
 
 export type FeaturedImageSlide = {
@@ -43,14 +44,7 @@ const FeaturedImageSlider = ({
 }: FeaturedImageSliderProps) => {
     const [index, setIndex] = useState(0);
     const [paused, setPaused] = useState(false);
-    const [progress, setProgress] = useState(0);
     const [lightboxOpen, setLightboxOpen] = useState(false);
-    // Pause rAF when scrolled off-screen so multiple sliders don't keep ticking
-    // when the section isn't visible. Defaults to true so we don't autoplay
-    // until we've actually observed visibility (avoids a brief tick before the
-    // observer fires).
-    const [offScreen, setOffScreen] = useState(true);
-    const rootRef = useRef<HTMLDivElement>(null);
     const swipeStartX = useRef<number | null>(null);
 
     const useArrows = controls.includes('arrows');
@@ -61,62 +55,14 @@ const FeaturedImageSlider = ({
     const next = () => setIndex((i) => (i + 1) % images.length);
     const prev = () => setIndex((i) => (i - 1 + images.length) % images.length);
 
-    // Pause autoplay while the lightbox is open so the slide doesn't advance
-    // out from under the user. Also pause when off-screen.
-    const effectivelyPaused = paused || lightboxOpen || offScreen;
-
-    useEffect(() => {
-        const el = rootRef.current;
-        if (!el) return;
-        // Skip when IntersectionObserver isn't available (e.g. older test envs).
-        if (typeof IntersectionObserver === 'undefined') {
-            // eslint-disable-next-line react-hooks/set-state-in-effect
-            setOffScreen(false);
-            return;
-        }
-        const io = new IntersectionObserver(
-            ([entry]) => {
-                // entry is always present — IO fires at least one per observed element.
-                if (entry) setOffScreen(!entry.isIntersecting);
-            },
-            { rootMargin: '100px' }
-        );
-        io.observe(el);
-        return () => io.disconnect();
-    }, []);
-
-    useEffect(() => {
-        // Reset progress when the active slide changes so the segmented-progress
-        // bar restarts from 0 for the new slide.
-        // eslint-disable-next-line react-hooks/set-state-in-effect
-        setProgress(0);
-    }, [index]);
-
-    useEffect(() => {
-        if (effectivelyPaused || images.length <= 1) return;
-        // Only the segmented-progress indicator actually reads `progress`.
-        // For other indicators, gate the autoplay loop on a single setTimeout
-        // instead of a 60Hz rAF + setState — saves ~60 component rerenders
-        // per second of autoplay.
-        if (indicator !== 'segmented-progress') {
-            const t = window.setTimeout(next, intervalMs);
-            return () => window.clearTimeout(t);
-        }
-        let raf = 0;
-        const start = performance.now() - progress * intervalMs;
-        const tick = (now: number) => {
-            const p = Math.min((now - start) / intervalMs, 1);
-            setProgress(p);
-            if (p < 1) {
-                raf = requestAnimationFrame(tick);
-            } else {
-                next();
-            }
-        };
-        raf = requestAnimationFrame(tick);
-        return () => cancelAnimationFrame(raf);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [effectivelyPaused, intervalMs, images.length, index, indicator]);
+    const { ref: rootRef, progress } = useCarouselAutoplay({
+        totalSlides: images.length,
+        activeIndex: index,
+        intervalMs,
+        indicator,
+        paused: paused || lightboxOpen,
+        onAdvance: next
+    });
 
     // Lightbox keyboard nav: Esc closes, arrows navigate.
     useEffect(() => {

--- a/src/components/LightboxOverlay.tsx
+++ b/src/components/LightboxOverlay.tsx
@@ -1,0 +1,61 @@
+import { createPortal } from 'react-dom';
+import SliderArrowButton from './SliderArrowButton';
+import ResponsiveImage from './ResponsiveImage';
+import type { FeaturedImageSlide } from './FeaturedImageSlider';
+
+export type LightboxOverlayProps = {
+    /** All slides — used to show prev/next arrows when there is more than one image. */
+    images: FeaturedImageSlide[];
+    /** The slide currently displayed in the lightbox. */
+    activeSlide: FeaturedImageSlide;
+    onClose: () => void;
+    onPrev: () => void;
+    onNext: () => void;
+};
+
+const LightboxOverlay = ({ images, activeSlide, onClose, onPrev, onNext }: LightboxOverlayProps) =>
+    createPortal(
+        <div
+            className="featured-image-slider__lightbox"
+            role="dialog"
+            aria-modal="true"
+            aria-label={activeSlide.alt}
+            onClick={onClose}
+        >
+            <ResponsiveImage
+                src={activeSlide.src}
+                srcWebp={activeSlide.srcWebp}
+                alt={activeSlide.alt}
+                className="featured-image-slider__lightbox-img"
+                onClick={(e) => e.stopPropagation()}
+            />
+            <button
+                type="button"
+                aria-label="Close"
+                className="featured-image-slider__lightbox-close"
+                onClick={(e) => {
+                    e.stopPropagation();
+                    onClose();
+                }}
+            >
+                ×
+            </button>
+            {images.length > 1 && (
+                <>
+                    <SliderArrowButton
+                        direction="prev"
+                        classScope="featured-image-slider__lightbox-arrow"
+                        onClick={onPrev}
+                    />
+                    <SliderArrowButton
+                        direction="next"
+                        classScope="featured-image-slider__lightbox-arrow"
+                        onClick={onNext}
+                    />
+                </>
+            )}
+        </div>,
+        document.body
+    );
+
+export default LightboxOverlay;

--- a/src/components/SliderCounterIndicator.tsx
+++ b/src/components/SliderCounterIndicator.tsx
@@ -1,0 +1,12 @@
+export type SliderCounterIndicatorProps = {
+    currentIndex: number;
+    totalSlides: number;
+};
+
+const SliderCounterIndicator = ({ currentIndex, totalSlides }: SliderCounterIndicatorProps) => (
+    <div className="featured-image-slider__counter" aria-live="polite">
+        {currentIndex + 1} / {totalSlides}
+    </div>
+);
+
+export default SliderCounterIndicator;

--- a/src/components/SliderFrostedDots.tsx
+++ b/src/components/SliderFrostedDots.tsx
@@ -1,0 +1,31 @@
+import type { FeaturedImageSlide } from './FeaturedImageSlider';
+
+export type SliderFrostedDotsProps = {
+    images: FeaturedImageSlide[];
+    currentIndex: number;
+    onSelect: (index: number) => void;
+};
+
+const SliderFrostedDots = ({ images, currentIndex, onSelect }: SliderFrostedDotsProps) => (
+    <div
+        className="featured-image-slider__dots featured-image-slider__dots--frosted"
+        role="tablist"
+    >
+        {images.map((img, i) => (
+            <button
+                key={img.src}
+                type="button"
+                role="tab"
+                aria-label={`Show image ${i + 1}`}
+                aria-selected={i === currentIndex}
+                className={`featured-image-slider__dot ${i === currentIndex ? 'is-active' : ''}`}
+                onClick={(e) => {
+                    e.stopPropagation();
+                    onSelect(i);
+                }}
+            />
+        ))}
+    </div>
+);
+
+export default SliderFrostedDots;

--- a/src/components/SliderOutlinedDots.tsx
+++ b/src/components/SliderOutlinedDots.tsx
@@ -1,0 +1,31 @@
+import type { FeaturedImageSlide } from './FeaturedImageSlider';
+
+export type SliderOutlinedDotsProps = {
+    images: FeaturedImageSlide[];
+    currentIndex: number;
+    onSelect: (index: number) => void;
+};
+
+const SliderOutlinedDots = ({ images, currentIndex, onSelect }: SliderOutlinedDotsProps) => (
+    <div
+        className="featured-image-slider__dots featured-image-slider__dots--outlined"
+        role="tablist"
+    >
+        {images.map((img, i) => (
+            <button
+                key={img.src}
+                type="button"
+                role="tab"
+                aria-label={`Show image ${i + 1}`}
+                aria-selected={i === currentIndex}
+                className={`featured-image-slider__dot ${i === currentIndex ? 'is-active' : ''}`}
+                onClick={(e) => {
+                    e.stopPropagation();
+                    onSelect(i);
+                }}
+            />
+        ))}
+    </div>
+);
+
+export default SliderOutlinedDots;

--- a/src/components/SliderSegmentedProgress.tsx
+++ b/src/components/SliderSegmentedProgress.tsx
@@ -1,0 +1,43 @@
+import type { FeaturedImageSlide } from './FeaturedImageSlider';
+
+export type SliderSegmentedProgressProps = {
+    images: FeaturedImageSlide[];
+    currentIndex: number;
+    /** Autoplay progress for the current slide (0–1). */
+    progress: number;
+    onSelect: (index: number) => void;
+};
+
+const SliderSegmentedProgress = ({
+    images,
+    currentIndex,
+    progress,
+    onSelect
+}: SliderSegmentedProgressProps) => (
+    <div className="featured-image-slider__segments" role="tablist">
+        {images.map((img, i) => {
+            const fill = i < currentIndex ? 1 : i === currentIndex ? progress : 0;
+            return (
+                <button
+                    key={img.src}
+                    type="button"
+                    role="tab"
+                    aria-label={`Show image ${i + 1}`}
+                    aria-selected={i === currentIndex}
+                    className="featured-image-slider__segment"
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        onSelect(i);
+                    }}
+                >
+                    <span
+                        className="featured-image-slider__segment-fill"
+                        style={{ width: `${fill * 100}%` }}
+                    />
+                </button>
+            );
+        })}
+    </div>
+);
+
+export default SliderSegmentedProgress;

--- a/src/hooks/useCarouselAutoplay.test.ts
+++ b/src/hooks/useCarouselAutoplay.test.ts
@@ -1,0 +1,249 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import React from 'react';
+import useCarouselAutoplay, { type UseCarouselAutoplayOptions, type UseCarouselAutoplayReturn } from './useCarouselAutoplay';
+
+// ── IntersectionObserver test double ─────────────────────────────────────────
+// setupTests.ts provides a no-op mock that fires isIntersecting: true on observe.
+// These unit tests need a controllable version that lets us fire arbitrary
+// entries and inspect disconnect calls.
+
+type IOCallback = (entries: IntersectionObserverEntry[]) => void;
+
+let lastIOCallback: IOCallback | null = null;
+let observeSpy: ReturnType<typeof vi.fn>;
+let disconnectSpy: ReturnType<typeof vi.fn>;
+
+function makeEntry(isIntersecting: boolean): IntersectionObserverEntry {
+    return { isIntersecting } as IntersectionObserverEntry;
+}
+
+function fireIO(isIntersecting: boolean) {
+    lastIOCallback?.([makeEntry(isIntersecting)]);
+}
+
+beforeEach(() => {
+    lastIOCallback = null;
+    observeSpy = vi.fn();
+    disconnectSpy = vi.fn();
+
+    global.IntersectionObserver = class {
+        constructor(cb: IOCallback) {
+            lastIOCallback = cb;
+        }
+        observe = observeSpy;
+        unobserve = vi.fn();
+        disconnect = disconnectSpy;
+        takeRecords = () => [];
+        root = null;
+        rootMargin = '';
+        thresholds = [];
+        scrollMargin = '';
+    } as unknown as typeof IntersectionObserver;
+
+    vi.useFakeTimers();
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+});
+
+// ── Harness component ─────────────────────────────────────────────────────────
+// Renders a real div so the hook's `ref.current` is a DOM element — needed
+// for the IO effect to run (it guards on `if (!el) return`).
+
+type HarnessProps = UseCarouselAutoplayOptions & {
+    onResult: (r: UseCarouselAutoplayReturn) => void;
+};
+
+function Harness({ onResult, ...opts }: HarnessProps) {
+    const result = useCarouselAutoplay(opts);
+    onResult(result);
+    return React.createElement('div', { ref: result.ref });
+}
+
+// ── Default options factory ───────────────────────────────────────────────────
+
+function makeOptions(overrides: Partial<UseCarouselAutoplayOptions> = {}): UseCarouselAutoplayOptions {
+    return {
+        totalSlides: 3,
+        activeIndex: 0,
+        intervalMs: 1000,
+        indicator: 'frosted-dots',
+        paused: false,
+        onAdvance: vi.fn(),
+        ...overrides
+    };
+}
+
+// ── Initial state ─────────────────────────────────────────────────────────────
+
+describe('useCarouselAutoplay — initial state', () => {
+    test('progress starts at 0', () => {
+        const results: UseCarouselAutoplayReturn[] = [];
+        render(React.createElement(Harness, { ...makeOptions(), onResult: (r) => results.push(r) }));
+        expect(results[0]!.progress).toBe(0);
+    });
+
+    test('ref is returned as a ref object', () => {
+        const results: UseCarouselAutoplayReturn[] = [];
+        render(React.createElement(Harness, { ...makeOptions(), onResult: (r) => results.push(r) }));
+        expect(results[0]!.ref).toBeDefined();
+        expect(typeof results[0]!.ref).toBe('object');
+    });
+});
+
+// ── setTimeout path: advances at configured interval ─────────────────────────
+
+describe('useCarouselAutoplay — setTimeout path (non-segmented-progress indicators)', () => {
+    test('calls onAdvance after intervalMs when on-screen and unpaused', () => {
+        const onAdvance = vi.fn();
+        render(React.createElement(Harness, { ...makeOptions({ onAdvance }), onResult: () => {} }));
+
+        // IO fires as soon as observe() is called in the effect.
+        // Simulate the element being visible.
+        act(() => { fireIO(true); });
+        expect(onAdvance).not.toHaveBeenCalled();
+
+        act(() => { vi.advanceTimersByTime(1000); });
+        expect(onAdvance).toHaveBeenCalledTimes(1);
+    });
+
+    test('does NOT advance while explicitly paused', () => {
+        const onAdvance = vi.fn();
+        render(React.createElement(Harness, { ...makeOptions({ onAdvance, paused: true }), onResult: () => {} }));
+
+        act(() => { fireIO(true); });
+        act(() => { vi.advanceTimersByTime(2000); });
+
+        expect(onAdvance).not.toHaveBeenCalled();
+    });
+
+    test('does NOT advance while offScreen (no IO fired yet)', () => {
+        const onAdvance = vi.fn();
+        render(React.createElement(Harness, { ...makeOptions({ onAdvance }), onResult: () => {} }));
+
+        // IO has been set up but hasn't fired — offScreen defaults to true.
+        act(() => { vi.advanceTimersByTime(2000); });
+        expect(onAdvance).not.toHaveBeenCalled();
+    });
+
+    test('does NOT advance when offScreen fires with isIntersecting: false', () => {
+        const onAdvance = vi.fn();
+        render(React.createElement(Harness, { ...makeOptions({ onAdvance }), onResult: () => {} }));
+
+        act(() => { fireIO(false); });
+        act(() => { vi.advanceTimersByTime(2000); });
+
+        expect(onAdvance).not.toHaveBeenCalled();
+    });
+
+    test('resumes advancing after coming back on-screen', () => {
+        const onAdvance = vi.fn();
+        render(React.createElement(Harness, { ...makeOptions({ onAdvance }), onResult: () => {} }));
+
+        // Go off-screen then come back on
+        act(() => { fireIO(false); });
+        act(() => { vi.advanceTimersByTime(1000); });
+        expect(onAdvance).not.toHaveBeenCalled();
+
+        act(() => { fireIO(true); });
+        act(() => { vi.advanceTimersByTime(1000); });
+        expect(onAdvance).toHaveBeenCalledTimes(1);
+    });
+
+    test('does NOT advance when totalSlides <= 1', () => {
+        const onAdvance = vi.fn();
+        render(React.createElement(Harness, { ...makeOptions({ onAdvance, totalSlides: 1 }), onResult: () => {} }));
+
+        act(() => { fireIO(true); });
+        act(() => { vi.advanceTimersByTime(2000); });
+        expect(onAdvance).not.toHaveBeenCalled();
+    });
+
+    test('resumes after unpausing', () => {
+        const onAdvance = vi.fn();
+        const opts = makeOptions({ onAdvance, paused: true });
+        const { rerender } = render(React.createElement(Harness, { ...opts, onResult: () => {} }));
+
+        act(() => { fireIO(true); });
+        act(() => { vi.advanceTimersByTime(1000); });
+        expect(onAdvance).not.toHaveBeenCalled();
+
+        const opts2 = makeOptions({ onAdvance, paused: false });
+        rerender(React.createElement(Harness, { ...opts2, onResult: () => {} }));
+        act(() => { vi.advanceTimersByTime(1000); });
+        expect(onAdvance).toHaveBeenCalledTimes(1);
+    });
+});
+
+// ── Cleanup on unmount ────────────────────────────────────────────────────────
+
+describe('useCarouselAutoplay — cleanup on unmount', () => {
+    test('clears the pending setTimeout on unmount', () => {
+        const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout');
+        const { unmount } = render(React.createElement(Harness, { ...makeOptions(), onResult: () => {} }));
+
+        act(() => { fireIO(true); });
+        act(() => { unmount(); });
+
+        expect(clearTimeoutSpy).toHaveBeenCalled();
+    });
+
+    test('disconnects IntersectionObserver on unmount', () => {
+        const { unmount } = render(React.createElement(Harness, { ...makeOptions(), onResult: () => {} }));
+
+        act(() => { unmount(); });
+
+        expect(disconnectSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('timer does not fire after unmount', () => {
+        const onAdvance = vi.fn();
+        const { unmount } = render(React.createElement(Harness, { ...makeOptions({ onAdvance }), onResult: () => {} }));
+
+        act(() => { fireIO(true); });
+        act(() => { unmount(); });
+        act(() => { vi.advanceTimersByTime(2000); });
+
+        expect(onAdvance).not.toHaveBeenCalled();
+    });
+});
+
+// ── activeIndex change resets progress ───────────────────────────────────────
+
+describe('useCarouselAutoplay — activeIndex change', () => {
+    test('progress resets to 0 when activeIndex changes', () => {
+        const results: UseCarouselAutoplayReturn[] = [];
+        const opts = makeOptions({ activeIndex: 0, indicator: 'segmented-progress' });
+        const { rerender } = render(React.createElement(Harness, { ...opts, onResult: (r) => results.push(r) }));
+
+        rerender(React.createElement(Harness, {
+            ...makeOptions({ activeIndex: 1, indicator: 'segmented-progress' }),
+            onResult: (r) => results.push(r)
+        }));
+
+        // Last recorded progress after the index change should be 0
+        const last = results[results.length - 1];
+        expect(last!.progress).toBe(0);
+    });
+});
+
+// ── offScreen toggle preserves state ─────────────────────────────────────────
+
+describe('useCarouselAutoplay — offScreen / onScreen toggle', () => {
+    test('going off-screen stops advancing', () => {
+        const onAdvance = vi.fn();
+        render(React.createElement(Harness, { ...makeOptions({ onAdvance }), onResult: () => {} }));
+
+        act(() => { fireIO(true); });
+        act(() => { vi.advanceTimersByTime(500); }); // halfway through
+        act(() => { fireIO(false); });               // go off-screen
+        act(() => { vi.advanceTimersByTime(2000); });
+
+        // At most 1 advance (the 500ms timer may have already been set but
+        // won't re-queue after going off-screen).
+        expect(onAdvance.mock.calls.length).toBeLessThanOrEqual(1);
+    });
+});

--- a/src/hooks/useCarouselAutoplay.ts
+++ b/src/hooks/useCarouselAutoplay.ts
@@ -1,0 +1,131 @@
+import { useEffect, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+
+export type UseCarouselAutoplayOptions = {
+    /** Total number of slides — autoplay is a no-op when this is ≤ 1. */
+    totalSlides: number;
+    /** The currently active slide index. The hook restarts its timer on every
+     *  index change so the interval always measures from the moment a slide
+     *  becomes active (whether via autoplay or manual navigation). */
+    activeIndex: number;
+    /** Autoplay interval in milliseconds. */
+    intervalMs: number;
+    /** Which indicator variant is rendered. Determines rAF vs setTimeout strategy:
+     *  'segmented-progress' drives a 60Hz rAF loop so the fill bar can animate;
+     *  all other variants use a single setTimeout (saves ~60 re-renders/second). */
+    indicator: string;
+    /** When true, autoplay is suspended (e.g. hover-pause or lightbox open). */
+    paused?: boolean;
+    /** Called once per autoplay tick — consumer should advance the slide index. */
+    onAdvance: () => void;
+};
+
+export type UseCarouselAutoplayReturn = {
+    /** Attach to the carousel root element for off-screen IO toggling. */
+    ref: RefObject<HTMLDivElement | null>;
+    /** Autoplay fill progress for the current slide (0–1).
+     *  Only meaningful when indicator === 'segmented-progress'; always 0 otherwise. */
+    progress: number;
+};
+
+/**
+ * Drives carousel autoplay with two complementary strategies:
+ *
+ * - **setTimeout path** — used for all indicators except 'segmented-progress'.
+ *   One timer per interval; zero re-renders between advances.
+ * - **rAF path** — used for 'segmented-progress'. Fires at 60 Hz so the fill
+ *   bar can animate; calls `onAdvance` when progress reaches 1.
+ *
+ * Autoplay pauses automatically when the carousel scrolls off-screen
+ * (IntersectionObserver with `rootMargin: '100px'`) so multiple sliders
+ * don't keep ticking when the section is not visible.
+ *
+ * The `offScreen` default is `true` so autoplay is held until the first
+ * intersection event, avoiding a brief tick before the observer fires.
+ */
+function useCarouselAutoplay({
+    totalSlides,
+    activeIndex,
+    intervalMs,
+    indicator,
+    paused = false,
+    onAdvance
+}: UseCarouselAutoplayOptions): UseCarouselAutoplayReturn {
+    // Defaults to true so autoplay is held until the first intersection event.
+    const [offScreen, setOffScreen] = useState(true);
+    const [progress, setProgress] = useState(0);
+    const ref = useRef<HTMLDivElement | null>(null);
+
+    // Keep a stable ref to onAdvance to avoid restarting the autoplay loop
+    // on every render of the parent component.
+    const onAdvanceRef = useRef(onAdvance);
+    useEffect(() => { onAdvanceRef.current = onAdvance; }, [onAdvance]);
+
+    // Set up the IntersectionObserver on the carousel root for offScreen toggling.
+    // Uses rootMargin: '100px' (not triggerOnce) — intentional toggle semantic.
+    useEffect(() => {
+        const el = ref.current;
+        if (!el) return;
+        // Skip when IntersectionObserver isn't available (e.g. older test envs).
+        if (typeof IntersectionObserver === 'undefined') {
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            setOffScreen(false);
+            return;
+        }
+        const io = new IntersectionObserver(
+            ([entry]) => {
+                // entry is always present — IO fires at least one per observed element.
+                if (entry) setOffScreen(!entry.isIntersecting);
+            },
+            { rootMargin: '100px' }
+        );
+        io.observe(el);
+        return () => io.disconnect();
+    }, []);
+
+    // Reset progress when the active slide changes so the segmented-progress
+    // bar restarts from 0 for the new slide.
+    useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setProgress(0);
+    }, [activeIndex]);
+
+    const effectivelyPaused = paused || offScreen;
+
+    useEffect(() => {
+        if (effectivelyPaused || totalSlides <= 1) return;
+
+        if (indicator !== 'segmented-progress') {
+            // One-shot setTimeout — no re-renders until the slide advances.
+            const t = window.setTimeout(() => onAdvanceRef.current(), intervalMs);
+            return () => window.clearTimeout(t);
+        }
+
+        // rAF path for the segmented-progress fill animation.
+        let raf = 0;
+        // Capture progress at effect-start time so a pause/resume resumes from
+        // the same fill position rather than restarting from 0.
+        // When a new slide starts, the reset effect above has already set
+        // progress to 0, so `progress * intervalMs` = 0 in that case.
+        const start = performance.now() - progress * intervalMs;
+        const tick = (now: number) => {
+            const p = Math.min((now - start) / intervalMs, 1);
+            setProgress(p);
+            if (p < 1) {
+                raf = requestAnimationFrame(tick);
+            } else {
+                onAdvanceRef.current();
+            }
+        };
+        raf = requestAnimationFrame(tick);
+        return () => cancelAnimationFrame(raf);
+        // `progress` is intentionally omitted from deps: we capture it as a
+        // snapshot at effect-start time (resume-from position). Including it
+        // would cause an infinite rAF → setProgress → effect-rerun loop.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [effectivelyPaused, intervalMs, totalSlides, activeIndex, indicator]);
+
+    return { ref, progress };
+}
+
+export default useCarouselAutoplay;


### PR DESCRIPTION
## Summary

- Extracts four indicator components (`SliderFrostedDots`, `SliderOutlinedDots`, `SliderSegmentedProgress`, `SliderCounterIndicator`) each with exported Props types
- Extracts `LightboxOverlay` component (the `createPortal` block) with `LightboxOverlayProps`
- Extracts `useCarouselAutoplay` hook — owns the rAF-vs-setTimeout autoplay strategy and the `rootMargin: '100px'` IntersectionObserver offScreen toggle
- Adds 14 unit tests for `useCarouselAutoplay` covering advances, pause/offScreen stops, resume, cleanup on unmount, progress reset on index change

## Test plan

- [ ] `npm run lint` — clean
- [ ] `npx tsc --noEmit` — clean
- [ ] `npm test` — 197 tests pass (40 files, including all storybook play functions: `LightboxOpened`, `Interacted`, `KeyboardAndSwipeInteracted`)
- [ ] `npm run build` — clean, no bundle growth
- [ ] FeaturedImageSlider.tsx: 319 → 203 lines