### PR TITLE
test: Phase 5.1+5.2 — close coverage gaps and add pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+npm run lint && npx tsc --noEmit && npx vitest run --project unit

--- a/src/components/FeaturedImageSlider.stories.tsx
+++ b/src/components/FeaturedImageSlider.stories.tsx
@@ -196,7 +196,8 @@ export const KeyboardAndSwipeInteracted: Story = {
 };
 
 // Opens the lightbox by clicking the active slide, then exercises
-// keyboard nav and the close button.
+// keyboard nav, lightbox arrow buttons (rendered in a portal on document.body),
+// and the close button.
 export const LightboxOpened: Story = {
     args: {
         images: triptych
@@ -209,6 +210,11 @@ export const LightboxOpened: Story = {
         await userEvent.click(activeSlide);
         await userEvent.keyboard('{ArrowRight}');
         await userEvent.keyboard('{ArrowLeft}');
+        // The lightbox is rendered via createPortal into document.body —
+        // query from there to reach the lightbox arrow buttons.
+        const body = within(document.body);
+        await userEvent.click(body.getByRole('button', { name: /Next image/ }));
+        await userEvent.click(body.getByRole('button', { name: /Previous image/ }));
         await userEvent.keyboard('{Escape}');
     }
 };

--- a/src/components/MomentumTabs.stories.tsx
+++ b/src/components/MomentumTabs.stories.tsx
@@ -108,6 +108,17 @@ export const ClickedThroughTabs: Story = {
     }
 };
 
+// Fires a resize event so the handleResize listener and the debounce
+// settle path (setIsResizing → re-measure → fade back in) are exercised.
+export const ResizeHandled: Story = {
+    play: async () => {
+        window.dispatchEvent(new Event('resize'));
+        // Allow the 450ms settle debounce to run so the full handler body
+        // (including the rAF fade-back-in path) is covered.
+        await new Promise((r) => setTimeout(r, 600));
+    }
+};
+
 // Exercises the keyboard navigation handlers (Arrow keys, Home, End).
 export const KeyboardNavigated: Story = {
     play: async ({ canvasElement }) => {

--- a/src/components/NavBar.stories.tsx
+++ b/src/components/NavBar.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { userEvent } from 'storybook/test';
+import { userEvent, within } from 'storybook/test';
 import NavBar from './NavBar';
 
 const meta: Meta<typeof NavBar> = {
@@ -33,10 +33,11 @@ export const Scrolled: Story = {
     }
 };
 
-// Drives the mobile collapse toggle (handleToggle) — the Bootstrap
-// Navbar.Toggle is hidden via CSS at desktop widths but the button
-// element is still present in the DOM, so we can click it directly.
+// Drives the mobile collapse toggle (handleToggle) at mobile viewport
+// width where Bootstrap renders the hamburger. Both clicks so we exercise
+// expanded=true and expanded=false paths through handleToggle.
 export const ToggleCollapsed: Story = {
+    parameters: { viewport: { defaultViewport: 'mobile1' } },
     play: async ({ canvasElement }) => {
         const toggle = canvasElement.querySelector(
             'button.navbar-toggler'
@@ -44,5 +45,20 @@ export const ToggleCollapsed: Story = {
         if (!toggle) return;
         await userEvent.click(toggle);
         await userEvent.click(toggle);
+    }
+};
+
+// Stubs window.open and clicks the resume button to exercise its onClick
+// handler without actually opening a new browser tab in the test runner.
+export const ResumeButtonClicked: Story = {
+    play: async ({ canvasElement, step }) => {
+        await step('stub window.open', () => {
+            // Replace window.open with a no-op so the click doesn't try to
+            // navigate the test browser to an external URL.
+            window.open = (() => null) as unknown as typeof window.open;
+        });
+        const canvas = within(canvasElement);
+        const resumeBtn = canvas.getByRole('button', { name: /My Resume/i });
+        await userEvent.click(resumeBtn);
     }
 };

--- a/vite.config.js
+++ b/vite.config.js
@@ -55,6 +55,7 @@ export default defineConfig({
     projects: [{
       extends: true,
       test: {
+        name: 'unit',
         globals: true,
         environment: "jsdom",
         setupFiles: "./src/setupTests.ts",


### PR DESCRIPTION
## Summary

- **NavBar toggle handler** (`ToggleCollapsed` story): added `parameters.viewport.defaultViewport='mobile1'` so the story renders at mobile width where Bootstrap shows the hamburger toggle — ensures `handleToggle` body is hit in the storybook project
- **NavBar resume button** (new `ResumeButtonClicked` story): stubs `window.open` with a no-op before clicking the resume button, avoiding browser tab navigation in the test runner
- **FeaturedImageSlider lightbox arrows** (`LightboxOpened` play extended): after opening the lightbox, queries `within(document.body)` (the portal target) and clicks prev/next lightbox arrows to cover `LightboxOverlay` arrow paths
- **MomentumTabs resize handler** (new `ResizeHandled` story): dispatches `window.resize` event and waits 600ms for the 450ms settle debounce + rAF fade-back path to execute
- **Pre-push hook** (`.husky/pre-push`): runs `lint + tsc --noEmit + vitest run --project unit`; the jsdom unit project is named `'unit'` in `vite.config.js` to enable `--project unit` filtering — excludes the chromium/storybook project which takes ~70s

## Test plan

- [ ] `npm run lint` — clean
- [ ] `npx tsc --noEmit` — clean
- [ ] `npm test` (both projects) — 108 storybook + 91 unit tests pass
- [ ] `npm run build` — clean
- [ ] Pre-push hook runs on push: `lint + tsc + unit` in ~5-6s (no chromium launch)
- [ ] ContactForm error branch NOT touched — already covered by unit tests per plan
- [ ] e2e/ directory NOT touched — deferred to follow-up PR per plan