### PR TITLE
refactor: Phase 6 — timings and env consolidation

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -3,6 +3,7 @@ import type { ChangeEvent, FormEvent } from "react";
 import { Col, Row } from "react-bootstrap";
 import FormStatusMessage from "./FormStatusMessage";
 import useFormSubmit, { type SubmitStatus } from "../hooks/useFormSubmit";
+import { FORM } from "../config/env";
 
 const BUTTON_LABELS: Record<SubmitStatus, string> = {
     idle: "Send",
@@ -91,7 +92,7 @@ const ContactForm = () => {
         }
 
         const payload = {
-            access_key: import.meta.env.VITE_FORM_ACCESS_KEY,
+            access_key: FORM.accessKey,
             subject: `Portfolio contact from ${formValues.firstName} ${formValues.lastName}`.trim(),
             ...formValues
         };

--- a/src/components/FeaturedImageSlider.tsx
+++ b/src/components/FeaturedImageSlider.tsx
@@ -7,6 +7,7 @@ import SliderSegmentedProgress from './SliderSegmentedProgress';
 import SliderCounterIndicator from './SliderCounterIndicator';
 import LightboxOverlay from './LightboxOverlay';
 import useCarouselAutoplay from '../hooks/useCarouselAutoplay';
+import { SLIDER_AUTOPLAY_INTERVAL } from '../config/timings';
 import '../assets/styles/FeaturedImageSlider.css';
 
 export type FeaturedImageSlide = {
@@ -37,7 +38,7 @@ const SWIPE_THRESHOLD_PX = 40;
 
 const FeaturedImageSlider = ({
     images,
-    intervalMs = 3690,
+    intervalMs = SLIDER_AUTOPLAY_INTERVAL,
     indicator = 'frosted-dots',
     controls = [],
     imagePosition = 'center'

--- a/src/components/HoverZoomPan.tsx
+++ b/src/components/HoverZoomPan.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState, type MouseEvent } from 'react';
 import ResponsiveImage from './ResponsiveImage';
+import { HOVER_ZOOM_PAN_TRANSITION } from '../config/timings';
 
 export type HoverZoomPanProps = {
     src: string;
@@ -8,7 +9,7 @@ export type HoverZoomPanProps = {
     alt: string;
     /** Multiplier on hover (1.63 = 163%). Defaults to 1.63. */
     zoomScale?: number;
-    /** Transition duration in ms for zoom in/out. Defaults to 693. */
+    /** Transition duration in ms for zoom in/out. Defaults to 963. */
     transitionMs?: number;
 };
 
@@ -17,7 +18,7 @@ const HoverZoomPan = ({
     srcWebp,
     alt,
     zoomScale = 1.63,
-    transitionMs = 963
+    transitionMs = HOVER_ZOOM_PAN_TRANSITION
 }: HoverZoomPanProps) => {
     // transformOrigin is purely visual state — write it to the DOM directly via
     // ref instead of going through React state. setState on every mousemove

--- a/src/components/MomentumTabs.tsx
+++ b/src/components/MomentumTabs.tsx
@@ -3,6 +3,7 @@ import '../assets/styles/MomentumTabs.css';
 import { TAB_ANIMATION } from './projectsTabAnimation';
 import useTabAnimation, { type IndicatorBox } from '../hooks/useTabAnimation';
 import { computeIndicatorPath } from '../hooks/indicatorPath';
+import { TABS_RESIZE_SETTLE } from '../config/timings';
 
 const SHRINK_MS = TAB_ANIMATION.indicatorShrinkMs;
 const EXPAND_MS = TAB_ANIMATION.indicatorExpandMs;
@@ -101,7 +102,7 @@ const MomentumTabs = <T extends string>({
                         setIsResizing(false);
                     });
                 });
-            }, 450);
+            }, TABS_RESIZE_SETTLE);
         };
         window.addEventListener('resize', handleResize);
         return () => {

--- a/src/components/SkillsCarousel.tsx
+++ b/src/components/SkillsCarousel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import CarouselDefault from "react-multi-carousel";
 const Carousel = (CarouselDefault as { default?: typeof CarouselDefault }).default || CarouselDefault;
 import { SKILLS } from "../data/skills";
+import { SKILLS_SNAP_RESET } from "../config/timings";
 
 type CarouselState = {
     currentSlide: number;
@@ -99,7 +100,7 @@ const SkillsCarousel = () => {
         setIsSnapping(true);
         if (snapResetRef.current) clearTimeout(snapResetRef.current);
         // Cover the snap setState + render + paint.
-        snapResetRef.current = setTimeout(() => setIsSnapping(false), 100);
+        snapResetRef.current = setTimeout(() => setIsSnapping(false), SKILLS_SNAP_RESET);
     };
 
     // Toggle `is-current` on the centered <li> by data-index. Carousel wraps

--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { FORM, type MockMode } from './env';
+
+describe('src/config/env', () => {
+    it('FORM.endpoint is a string (empty in test mode)', () => {
+        // In test mode validation is suppressed so required() returns ''.
+        expect(typeof FORM.endpoint).toBe('string');
+    });
+
+    it('FORM.accessKey is a string (empty in test mode)', () => {
+        expect(typeof FORM.accessKey).toBe('string');
+    });
+
+    it('FORM.mockMode is one of the allowed values', () => {
+        const allowed: MockMode[] = ['', 'success', 'error', 'throw'];
+        expect(allowed).toContain(FORM.mockMode);
+    });
+});

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,39 @@
+/**
+ * Single import boundary for environment-validated config.
+ * vite-env.d.ts types the raw variables; this module reads + validates them
+ * at startup so missing vars surface at boot, not at first form submit.
+ *
+ * Validation is gated on MODE !== 'test' so the jsdom test environment
+ * (which doesn't define the VITE_ vars) doesn't blow up on import.
+ * The existing dispatchForm guard in useFormSubmit already short-circuits
+ * all real network calls in test mode, so the empty strings are never used.
+ */
+
+const isTest = import.meta.env.MODE === 'test';
+
+/**
+ * Assert that an env var is present and non-empty.
+ * Returns an empty string in test mode so test imports don't throw.
+ */
+const required = (key: string): string => {
+    if (isTest) return '';
+    const value = (import.meta.env as Record<string, string | undefined>)[key];
+    if (typeof value !== 'string' || value === '') {
+        throw new Error(`Missing required env var: ${key}`);
+    }
+    return value;
+};
+
+export type MockMode = '' | 'success' | 'error' | 'throw';
+
+export type FormConfig = {
+    endpoint: string;
+    accessKey: string;
+    mockMode: MockMode;
+};
+
+export const FORM: FormConfig = {
+    endpoint: required('VITE_FORM_ENDPOINT'),
+    accessKey: required('VITE_FORM_ACCESS_KEY'),
+    mockMode: ((import.meta.env.VITE_MOCK_FORM as MockMode | undefined) ?? '') as MockMode,
+};

--- a/src/config/timings.ts
+++ b/src/config/timings.ts
@@ -1,0 +1,24 @@
+/**
+ * Centralized timing constants. All durations in milliseconds.
+ * Values were chosen empirically by Miguel — do not "round" without testing.
+ *
+ * Pattern follows src/components/projectsTabAnimation.ts.
+ */
+
+/** FeaturedImageSlider autoplay interval between slides. */
+export const SLIDER_AUTOPLAY_INTERVAL = 3690;
+
+/** HoverZoomPan zoom-in/out transition duration. */
+export const HOVER_ZOOM_PAN_TRANSITION = 963;
+
+/** MomentumTabs: how long after the last resize event before re-measuring indicator coords. */
+export const TABS_RESIZE_SETTLE = 450;
+
+/** MomentumTabs / useTabAnimation: initial-wrap expand delay (leading pause before trace starts). */
+export const TABS_INITIAL_WRAP_DELAY = 80;
+
+/** SkillsCarousel: how long to suppress filter transitions while the carousel snaps clone→original. */
+export const SKILLS_SNAP_RESET = 100;
+
+/** useFormSubmit: simulated network latency when VITE_MOCK_FORM is active in dev. */
+export const FORM_MOCK_DELAY = 500;

--- a/src/hooks/useFormSubmit.ts
+++ b/src/hooks/useFormSubmit.ts
@@ -1,5 +1,7 @@
 import { useState, useCallback } from 'react';
 import axios from 'axios';
+import { FORM_MOCK_DELAY } from '../config/timings';
+import { FORM } from '../config/env';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -35,21 +37,21 @@ type SubmitResponse = { status: number; data: { success: boolean; message: strin
  * mocks take full control.
  */
 const dispatchForm = async (payload: Record<string, string>): Promise<SubmitResponse> => {
-    const mock = import.meta.env.VITE_MOCK_FORM;
+    const { mockMode, endpoint } = FORM;
     const isMockable = import.meta.env.DEV && import.meta.env.MODE !== 'test';
 
-    if (isMockable && mock) {
-        await new Promise<void>((resolve) => setTimeout(resolve, 500));
-        if (mock === 'error') {
+    if (isMockable && mockMode) {
+        await new Promise<void>((resolve) => setTimeout(resolve, FORM_MOCK_DELAY));
+        if (mockMode === 'error') {
             return { status: 200, data: { success: false, message: '[MOCK] Spam detected' } };
         }
-        if (mock === 'throw') {
+        if (mockMode === 'throw') {
             throw new Error('[MOCK] Request failed with status code 429');
         }
         return { status: 200, data: { success: true, message: '[MOCK] Email sent' } };
     }
 
-    return axios.post(import.meta.env.VITE_FORM_ENDPOINT, payload);
+    return axios.post(endpoint, payload);
 };
 
 // ---------------------------------------------------------------------------

--- a/src/hooks/useTabAnimation.ts
+++ b/src/hooks/useTabAnimation.ts
@@ -1,5 +1,6 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { TAB_ANIMATION } from '../components/projectsTabAnimation';
+import { TABS_INITIAL_WRAP_DELAY } from '../config/timings';
 
 const SHRINK_MS = TAB_ANIMATION.indicatorShrinkMs;
 const SLIDE_STRETCH_MS = TAB_ANIMATION.indicatorSlideStretchMs;
@@ -98,11 +99,11 @@ function useTabAnimation(
         if (expandKickedRef.current || !enabled || !indicator) return;
         expandKickedRef.current = true;
         isAnimatingRef.current = true;
-        const t = window.setTimeout(() => setExpanded(true), 80);
+        const t = window.setTimeout(() => setExpanded(true), TABS_INITIAL_WRAP_DELAY);
         const tFrost = window.setTimeout(() => {
             setWrapComplete(true);
             isAnimatingRef.current = false;
-        }, 80 + EXPAND_MS);
+        }, TABS_INITIAL_WRAP_DELAY + EXPAND_MS);
         transitionTimers.current.push(t, tFrost);
     }, [enabled, indicator]);
 


### PR DESCRIPTION
## Summary

- **6.1 `src/config/timings.ts`** — new module centralizing 6 scattered ms values across `FeaturedImageSlider`, `MomentumTabs`, `useTabAnimation`, `SkillsCarousel`, and `useFormSubmit`. Pattern follows `projectsTabAnimation.ts`.
- **JSDoc fix** — `HoverZoomPan.transitionMs` jsdoc said "Defaults to 693"; actual default is 963. Fixed to match.
- **6.2 `src/config/env.ts`** — single import boundary for `VITE_FORM_ENDPOINT`, `VITE_FORM_ACCESS_KEY`, `VITE_MOCK_FORM`. Validation throws on missing vars at startup, gated on `MODE !== 'test'` so jsdom environment doesn't blow up. `ContactForm` and `useFormSubmit` now import from `FORM` config.
- **`src/config/env.test.ts`** — 3 smoke tests confirming field types and mockMode union narrowing.
- **6.3 skipped** — `Projects.css` is organized by component type (ProjectCard, FeaturedProjectCard, skeletons), not by tab section. Phase 3.1's tab splits don't map to natural CSS boundaries, so splitting would create cross-file cascade dependencies without payoff.

## Test plan

- [ ] `npm run lint` — clean
- [ ] `npx tsc --noEmit` — clean
- [ ] `npm test --project unit` — 13 files, 97 tests green
- [ ] `npm run build` — clean build, no size regression
- [ ] `grep -rn "import.meta.env" src/` — only appears in `src/config/env.ts` (boundary module) and `src/hooks/useFormSubmit.ts` (Vite built-ins `DEV`/`MODE`) and `src/components/ResumeButton.tsx` (`BASE_URL` built-in)