### PR TITLE
fix(styles): set Skills + Built With border-radius to 39px

### DIFF
--- a/src/assets/styles/Footer.css
+++ b/src/assets/styles/Footer.css
@@ -1,7 +1,7 @@
 /* ==== Pre-Footer ==== */
 .built-with {
     background: #fff;
-    border-radius: 55px;
+    border-radius: 39px;
     color: var(--almost-black);
     padding: 40px 40px 30px;
     margin: -122px auto 80px;

--- a/src/assets/styles/Skills.css
+++ b/src/assets/styles/Skills.css
@@ -17,7 +17,7 @@
 .skills-content {
     background: #151515;
     background: #1f1f1f;
-    border-radius: 64px;
+    border-radius: 39px;
     text-align: center;
     margin-top: -60px;
     padding: 60px 3em;


### PR DESCRIPTION
## Summary
- `.skills-content` (Skills.css): 64px → 39px
- `.built-with` (Footer.css): 55px → 39px

Tightens corner softness for visual consistency between the two content blocks. Will produce a Chromatic visual diff (intentional).

## Test plan
- [x] Visual verification in browser at /#skills and pre-footer
- [ ] Accept Chromatic baseline change