### PR TITLE
fix(hero): make .tagline contrast computable for axe-core

### DIFF
--- a/src/assets/styles/Hero.css
+++ b/src/assets/styles/Hero.css
@@ -37,7 +37,13 @@
 
 .hero .content .tagline {
     display: inline-block;
-    background: linear-gradient(90.21deg, rgba(170, 54, 124, 0.5) -5.91%, rgba(74, 47, 189, 0.5) 111.58%);
+    /* Solid background-color underlies the gradient so axe-core can compute
+       contrast (it can't see through layered alpha + ancestor pseudo
+       overlays). The 50% alpha gradient still paints over this; visual
+       result is unchanged because the area behind the tagline was already
+       near-black via .hero::before. */
+    background-color: var(--bg-color);
+    background-image: linear-gradient(90.21deg, rgba(170, 54, 124, 0.5) -5.91%, rgba(74, 47, 189, 0.5) 111.58%);
     border: 1px solid rgba(255, 255, 255, 0.5);
     font-size: 20px;
     font-size: .8em;


### PR DESCRIPTION
## Summary

Storybook a11y panel was reporting:
> **Inconclusive — Color contrast: Element's background color could not be determined due to a pseudo element.**

…on the `.tagline` span in HeroContent stories (Default + ChatCtaClicked).

Root cause: the `.tagline` had `background: linear-gradient(...)` at 50% alpha, sitting under the `.hero::before` darkening overlay. axe-core can't compute effective background through layered alpha + ancestor pseudo-elements, so it bailed out as Inconclusive.

Fix: split the shorthand into `background-color: var(--bg-color)` + `background-image: linear-gradient(...)`. axe-core sees a solid backing color it can reason about; the gradient still paints visibly on top.

**No visual change** — the area behind the tagline was already near-black via `.hero::before`, which matches `--bg-color` (#121212).

## Test plan
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Refresh Storybook → HeroContent → Default + Chat Cta Clicked. The Inconclusive count on Color contrast should drop to 0 (or move to Passes).
- [ ] Visual: tagline appearance unchanged on /#home