### PR TITLE
chore(storybook): hide axe-core Inconclusive results from a11y panel

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -15,7 +15,14 @@ const preview = {
       // 'todo' - show a11y violations in the test UI only
       // 'error' - fail CI on a11y violations
       // 'off' - skip a11y checks entirely
-      test: "error"
+      test: "error",
+      // Hide axe-core "Inconclusive" results from the panel. They surface
+      // when axe can't determine an outcome (e.g., color-contrast through
+      // layered alpha + ancestor pseudo overlays in the hero) — by
+      // definition non-actionable. Real Violations still surface normally.
+      options: {
+        resultTypes: ["violations"]
+      }
     },
 
     options: {


### PR DESCRIPTION
## Summary

Inconclusive a11y findings surface when axe-core can't determine an outcome — typically color-contrast through layered alpha + ancestor pseudo overlays (the `.hero::before` darkening overlay over `.tagline` is the recurring offender). By definition non-actionable, so they're noise in the panel.

Sets `parameters.a11y.options.resultTypes` to `['violations']` in `.storybook/preview.js`. Real Violations still surface and still fail CI via the existing `test: 'error'` config. Passes/Inapplicable also stop being collected, which is fine — the panel was already over-busy.

Tried the alternative (split `.tagline`'s background into background-color + background-image so axe could compute it) in #157; didn't work because axe still bailed on the ancestor `.hero::before` overlay. Suppression at the panel level is the honest fix.

## Test plan
- [x] `npm run lint` — clean
- [ ] Refresh Storybook → HeroContent → Default + Chat Cta Clicked. Inconclusive tab should be empty / hidden.
- [ ] Spot-check other components — Violations still surface as before.