### PR TITLE
chore(stories): disable axe color-contrast on Hero + HeroContent stories

### DIFF
--- a/src/components/Hero.stories.tsx
+++ b/src/components/Hero.stories.tsx
@@ -3,7 +3,20 @@ import Hero from './Hero';
 const meta = {
     title: 'Showcase/Sections/Hero',
     component: Hero,
-    parameters: { layout: 'fullscreen', docs: { description: { component: "The hero section that opens the portfolio. Full-bleed background with bitmoji illustration and an animated typing CTA." } } }
+    parameters: {
+        layout: 'fullscreen',
+        docs: { description: { component: "The hero section that opens the portfolio. Full-bleed background with bitmoji illustration and an animated typing CTA." } },
+        a11y: {
+            // .hero::before darkening pseudo overlay sits above .tagline's
+            // translucent gradient. axe-core can't compute effective background
+            // through that composition and emits an Inconclusive (not a
+            // violation). Real contrast verified manually. Same rule applied
+            // on the HeroContent composite stories for the same reason.
+            config: {
+                rules: [{ id: 'color-contrast', enabled: false }]
+            }
+        }
+    }
 };
 
 export default meta;

--- a/src/components/HeroContent.stories.tsx
+++ b/src/components/HeroContent.stories.tsx
@@ -42,7 +42,22 @@ const meta: Meta<typeof HeroContent> = {
             </section>
         )
     ],
-    parameters: { layout: 'fullscreen', docs: { description: { component: "The text + CTA block inside Hero. Drives the typing-effect headline cycle." } } }
+    parameters: {
+        layout: 'fullscreen',
+        docs: { description: { component: "The text + CTA block inside Hero. Drives the typing-effect headline cycle." } },
+        a11y: {
+            // The story decorator mimics the .hero layout, which means the
+            // `.hero::before` darkening pseudo overlay is rendered above the
+            // .tagline's translucent gradient. axe-core can't compute effective
+            // background through that composition and reports an Inconclusive
+            // (not a violation). Real contrast is verified manually. Disable
+            // the single rule on this component only — every other component's
+            // stories still run color-contrast normally.
+            config: {
+                rules: [{ id: 'color-contrast', enabled: false }]
+            }
+        }
+    }
 };
 
 export default meta;


### PR DESCRIPTION
## Summary

Disable axe-core's color-contrast rule on the Hero (showcase) and HeroContent (composite) stories. The `.hero::before` darkening pseudo overlay sits above `.tagline`'s translucent gradient and axe can't compute effective background through that composition — it emits an **Inconclusive** finding, not a violation, which spams the panel.

Tried two narrower fixes first that didn't work:
- #157: split `.tagline`'s `background:` shorthand into `background-color` + `background-image`. axe still bailed on the ancestor pseudo.
- #158: global `resultTypes: ['violations']` in preview.js. The addon panel ignores it for the Inconclusive tab rendering.

Per-story rule disable is the precise fix:
- Real contrast on `.tagline` verified manually
- Every other component's stories still run color-contrast normally
- Inline comments in both story files explain the rationale

Files touched:
- `src/components/HeroContent.stories.tsx` — covers the composite view (Default + Chat Cta Clicked)
- `src/components/Hero.stories.tsx` — covers the showcase view (Default)

## Test plan
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Refresh Storybook → Showcase/Sections/Hero (Default) — Inconclusive count → 0
- [ ] Refresh Storybook → Composites/HeroContent (Default + Chat Cta Clicked) — Inconclusive count → 0
- [ ] Sanity check another component (NavBar, Skills): Inconclusive panel still functions normally there