### PR TITLE
chore(storybook): support /storybook subroute for migueldotl.github.io

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -18,11 +18,17 @@ const config = {
      non-empty value (e.g. our local "throw" used for live-site error-UI
      testing) bypasses the per-story axios mocks and forces every state
      story into the error path. */
-  viteFinal: async (config) => {
+  viteFinal: async (config, { configType }) => {
     config.define = {
       ...config.define,
       'import.meta.env.VITE_MOCK_FORM': JSON.stringify('')
     };
+    /* Set base path only when building for the public migueldotl.github.io/storybook
+       subroute. Chromatic serves from its own URL prefix and the local dev server
+       runs at root, so default stays "/". Opt in via STORYBOOK_PUBLIC_DEPLOY=1. */
+    if (configType === 'PRODUCTION' && process.env.STORYBOOK_PUBLIC_DEPLOY === '1') {
+      config.base = '/storybook/';
+    }
     return config;
   }
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "chromatic:baseline": "chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --auto-accept-changes",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
+    "build-storybook:public": "STORYBOOK_PUBLIC_DEPLOY=1 storybook build",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,33 +11,39 @@ const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(file
 // HTML so the browser can fetch it in parallel with the JS bundle instead
 // of waiting for React to discover it. The asset filename is hashed by
 // Vite at build time, so we look it up in the bundle map.
-const preloadLcpImage = () => ({
-  name: 'preload-lcp-image',
-  apply: 'build',
-  transformIndexHtml: {
-    order: 'post',
-    handler(_html, ctx) {
-      if (!ctx.bundle) return;
-      const key = Object.keys(ctx.bundle).find(
-        (k) => k.includes('bitmoji-space-planet-2') && k.endsWith('.webp')
-      );
-      if (!key) return;
-      return [
-        {
-          tag: 'link',
-          attrs: {
-            rel: 'preload',
-            as: 'image',
-            type: 'image/webp',
-            href: `/${key}`,
-            fetchpriority: 'high'
-          },
-          injectTo: 'head'
-        }
-      ];
+const preloadLcpImage = () => {
+  let base = '/';
+  return {
+    name: 'preload-lcp-image',
+    apply: 'build',
+    configResolved(resolved) {
+      base = resolved.base || '/';
+    },
+    transformIndexHtml: {
+      order: 'post',
+      handler(_html, ctx) {
+        if (!ctx.bundle) return;
+        const key = Object.keys(ctx.bundle).find(
+          (k) => k.includes('bitmoji-space-planet-2') && k.endsWith('.webp')
+        );
+        if (!key) return;
+        return [
+          {
+            tag: 'link',
+            attrs: {
+              rel: 'preload',
+              as: 'image',
+              type: 'image/webp',
+              href: `${base}${key}`,
+              fetchpriority: 'high'
+            },
+            injectTo: 'head'
+          }
+        ];
+      }
     }
-  }
-});
+  };
+};
 
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({


### PR DESCRIPTION
## Summary

Opt-in base-path support so Storybook can be hosted at `migueldotl.github.io/storybook` alongside the main portfolio site, unblocking the Built With repurpose plan.

- **`.storybook/main.js`:** `viteFinal` sets `config.base = '/storybook/'` only when `STORYBOOK_PUBLIC_DEPLOY=1` AND building for production. Default builds (Chromatic, local dev) stay at `/`.
- **`vite.config.js`:** `preloadLcpImage` plugin reads `resolved.base` via the `configResolved` hook so the LCP preload URL is base-aware. Was previously hardcoded to `/${key}`, would 404 under any subroute.
- **`package.json`:** adds `build-storybook:public` script. Sibling to `build-storybook` — default behavior unchanged.

## Verified
- `npm run build-storybook` → `./assets/...` (relative, Chromatic-compatible)
- `npm run build-storybook:public` → `/storybook/assets/...` (absolute under subroute)

## Test plan
- [x] Both build variants succeed
- [x] LCP preload href correctly prefixed in public build only
- [ ] Once deployed: visit `migueldotl.github.io/storybook`, navigate stories, no 404s in console