### PR TITLE
fix(css): drop -webkit-backdrop-filter so esbuild stops stripping unprefixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "react-bootstrap": "^2.5.0",
     "react-bootstrap-icons": "^1.9.1",
     "react-dom": "^18.2.0",
-"react-multi-carousel": "^2.8.2"
+    "react-multi-carousel": "^2.8.2"
   },
   "scripts": {
     "dev": "vite",

--- a/src/assets/styles/FeaturedImageSlider.css
+++ b/src/assets/styles/FeaturedImageSlider.css
@@ -47,7 +47,6 @@
 .featured-image-slider__dots--frosted .featured-image-slider__dot {
     background: rgba(255, 255, 255, 0.25);
     backdrop-filter: blur(6px) saturate(1.3);
-    -webkit-backdrop-filter: blur(6px) saturate(1.3);
     border: 1px solid rgba(255, 255, 255, 0.35);
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
 }
@@ -107,7 +106,6 @@
     border-radius: 999px;
     background: rgba(0, 0, 0, 0.35);
     backdrop-filter: blur(6px) saturate(1.3);
-    -webkit-backdrop-filter: blur(6px) saturate(1.3);
     border: 1px solid rgba(255, 255, 255, 0.12);
 }
 
@@ -161,7 +159,6 @@
     border: 1px solid rgba(255, 255, 255, 0.18);
     background: rgba(0, 0, 0, 0.4);
     backdrop-filter: blur(6px) saturate(1.3);
-    -webkit-backdrop-filter: blur(6px) saturate(1.3);
     color: #fff;
     font-size: 22px;
     line-height: 1;
@@ -202,7 +199,6 @@
     inset: 0;
     background: rgba(0, 0, 0, 0.88);
     backdrop-filter: blur(4px);
-    -webkit-backdrop-filter: blur(4px);
     z-index: 9999;
     display: flex;
     align-items: center;
@@ -232,7 +228,6 @@
     color: #fff;
     border: 1px solid rgba(255, 255, 255, 0.18);
     backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
     cursor: pointer;
     transition: background 180ms ease, transform 180ms ease;
 }

--- a/src/assets/styles/MomentumTabs.css
+++ b/src/assets/styles/MomentumTabs.css
@@ -40,7 +40,6 @@
     inset: 0;
     background: rgba(255, 255, 255, 0.05);
     backdrop-filter: blur(10px) saturate(1.3);
-    -webkit-backdrop-filter: blur(10px) saturate(1.3);
     opacity: 0;
     transition: opacity 280ms ease;
     pointer-events: none;

--- a/src/assets/styles/Projects.css
+++ b/src/assets/styles/Projects.css
@@ -137,14 +137,12 @@ a.project-card {
     margin: 1em auto;
     background: rgba(255, 255, 255, 0.05);
     backdrop-filter: blur(6px) saturate(1.3);
-    -webkit-backdrop-filter: blur(6px) saturate(1.3);
     transition: 0.3s ease-in-out;
 }
 
 .project-card .btn.btn-outline-secondary:hover {
     background-color: rgba(0, 0, 0, 0.3);
     backdrop-filter: blur(6px) saturate(1.3);
-    -webkit-backdrop-filter: blur(6px) saturate(1.3);
 }
 
 .project-image {
@@ -170,7 +168,6 @@ a.project-card {
         rgba(74, 47, 189, 0.55) 111.58%
     );
     backdrop-filter: blur(8px) saturate(1.4);
-    -webkit-backdrop-filter: blur(8px) saturate(1.4);
     position: absolute;
     width: 100%;
     height: 0;
@@ -381,7 +378,6 @@ a.project-card {
     color: #fff;
     background: rgba(255, 255, 255, 0.05);
     backdrop-filter: blur(6px) saturate(1.3);
-    -webkit-backdrop-filter: blur(6px) saturate(1.3);
     transition: background-color 0.3s ease-in-out, border-color 0.3s ease-in-out;
 }
 


### PR DESCRIPTION
## Bug

Frosted-glass effects missing on the deployed site (Firefox specifically). Local dev was fine.

## Root cause

With both `backdrop-filter` and `-webkit-backdrop-filter` declared in a rule, esbuild's CSS minifier consolidates to ONE based on target browsers. Vite's default ES-modules target includes Safari 14, which only supports `-webkit-backdrop-filter` — esbuild keeps that and silently drops the unprefixed. Firefox doesn't accept the -webkit- prefix (it's WebKit/Blink-only), so Firefox loses the blur.

## Fix

Drop `-webkit-backdrop-filter` from source. esbuild's CSS minifier still auto-adds the -webkit- prefix per target — but with no duplicate to consolidate, the unprefixed survives. Verified: built CSS now has both prefixed AND unprefixed side by side.

10 `-webkit-backdrop-filter` lines removed across:
- `src/assets/styles/Projects.css` (4)
- `src/assets/styles/FeaturedImageSlider.css` (5)
- `src/assets/styles/MomentumTabs.css` (1)

Also: drops a transient `lightningcss` devDep that was added during diagnosis. Was not the right fix.

## Test plan
- [x] `npm run build` — clean
- [x] Built CSS has both `backdrop-filter` and `-webkit-backdrop-filter` side by side
- [ ] After deploy: Firefox shows blur on project-card buttons, momentum tabs frosted state, slider dots, lightbox