### PR TITLE
fix(purgecss): safelist featured-image-slider__ family for runtime modifiers

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -35,6 +35,12 @@ export default {
                               // arrows are `react-multiple-carousel__arrow*`
                               // (plural). Both prefixes need to be safelisted.
                               /^react-multiple-carousel/,
+                              // Slider chrome (incl. lightbox) builds modifier
+                              // classes at runtime via template literals like
+                              // `${classScope}--${direction}` — PurgeCSS can't
+                              // see those in source, so safelist the whole
+                              // featured-image-slider__ family.
+                              /^featured-image-slider/,
                               /^col-/,
                               /^row/,
                               /^container/,


### PR DESCRIPTION
## Bug

Lightbox arrows misplaced on the deployed site:
- right arrow appeared in the center of the image
- left arrow not visible at all

Same pattern would affect the slider chrome arrows and the dot indicator variants (frosted / outlined / segmented).

## Root cause

`SliderArrowButton` builds modifier classes at runtime: `${classScope}--${direction}`. PurgeCSS only scans for **static** class strings in source files — it can't see the runtime-built `featured-image-slider__lightbox-arrow--prev` etc., so it strips those rules from prod CSS. Same issue would apply to:
- `featured-image-slider__arrow--prev` / `--next`
- `featured-image-slider__dots--frosted` / `--outlined` / `--segmented`

## Fix

Add `/^featured-image-slider/` to the standard safelist in `postcss.config.js`. Covers the entire slider chrome family in one regex.

## Verified

- `npm run build` produces `dist/assets/Projects-*.css` containing the `--prev` / `--next` rules and dot variant rules.

## Test plan
- [x] `npm run build` — clean
- [ ] After deploy: open project featured slider, click image to open lightbox, prev/next arrows visible at left/right edges; main slider arrows also visible on hover.