### PR TITLE
fix: give Footer story headroom for PreFooter's negative margin

### DIFF
--- a/src/components/Footer.stories.tsx
+++ b/src/components/Footer.stories.tsx
@@ -1,9 +1,22 @@
+import type { Meta } from '@storybook/react-vite';
 import Footer from './Footer';
 
-const meta = {
+const meta: Meta<typeof Footer> = {
     title: 'Showcase/Sections/Footer',
     component: Footer,
-    parameters: { layout: 'fullscreen', docs: { description: { component: "Page footer — built-with attribution + social icons + copyright. Sits below PreFooter on the live site." } } }
+    decorators: [
+        (Story) => (
+            <div
+                style={{
+                    background: 'linear-gradient(90deg, #5b2a86 0%, #4a6fc7 100%)',
+                    paddingTop: 180
+                }}
+            >
+                <Story />
+            </div>
+        )
+    ],
+    parameters: { layout: 'fullscreen', docs: { description: { component: "Page footer — built-with attribution + social icons + copyright. Sits below PreFooter on the live site. PreFooter has margin-top: -122px to overlap the section above; the decorator adds headroom so the story isn't clipped." } } }
 };
 
 export default meta;


### PR DESCRIPTION
## Summary
- Adds a decorator to `Footer.stories.tsx` mirroring the existing pattern in `PreFooter.stories.tsx`: gradient `<div>` wrapper with `paddingTop: 180` so PreFooter's `margin-top: -122px` doesn't pull the story above the canvas viewport.
- Storybook-only fix; live site renders correctly because ContactMe sits above the Footer on production.

Closes #171

## Test plan
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 88/88 unit tests pass (pre-push gate)
- [ ] Visual check in Storybook: `Showcase/Sections/Footer` shows PreFooter "Peek under the hood" heading at top of canvas, no scroll needed