### PR TITLE
chore: merge dev → main — PreFooter peek-under-the-hood + Footer story fix

### DIFF
--- a/src/assets/styles/Footer.css
+++ b/src/assets/styles/Footer.css
@@ -55,6 +55,337 @@
     padding: 0 1rem 2rem;
 }
 
+/* Registered angle property so the GH gradient can rotate smoothly when
+   the SB button is hovered. CSS can't transition gradient strings, but it
+   can transition a registered <angle> custom property used inside one. */
+@property --cta-grad-angle {
+    syntax: '<angle>';
+    inherits: false;
+    initial-value: 131deg;
+}
+
+/* === New layout: split screenshot + copy === */
+
+.built-with.v-screenshot {
+    padding: 32px 32px 28px;
+}
+
+.v-screenshot__h {
+    text-align: left;
+    margin-bottom: 1em;
+}
+
+.built-with .lead-copy {
+    color: var(--mid-grey);
+    font-size: 0.95rem;
+    line-height: 1.55;
+    margin-bottom: 1.5em;
+}
+
+.built-with .lead-copy a {
+    background: linear-gradient(131deg, #aa367c 28%, #4a2fbd 71%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+    font-weight: 600;
+    text-decoration: underline;
+    text-decoration-color: #aa367c;
+    text-underline-offset: 2px;
+    text-decoration-thickness: 1.5px;
+    transition: text-decoration-thickness 0.15s ease, text-decoration-color 0.15s ease;
+}
+
+.built-with .lead-copy a:hover {
+    text-decoration-color: #4a2fbd;
+    text-decoration-thickness: 2.5px;
+}
+
+.cta-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.8em;
+    flex-wrap: wrap;
+    margin-bottom: 0.4em;
+}
+
+.cta-row--start {
+    justify-content: flex-start;
+}
+
+/* Rectangular button shape — applied on the cta-row to flip both buttons
+   inside from pill (default 999px) to sharp rectangle. Matches the
+   Contact form Send button pattern. */
+.cta-row--rect .cta-btn {
+    border-radius: 0;
+}
+
+.cta-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5em;
+    padding: 0.7em 1.4em;
+    border-radius: 999px;
+    font-weight: 600;
+    text-decoration: none;
+    --cta-grad-angle: 131deg;
+    background: linear-gradient(var(--cta-grad-angle), #aa367c 28%, #4a2fbd 71%);
+    color: #fff;
+    transition:
+        transform 0.18s ease,
+        box-shadow 0.18s ease,
+        --cta-grad-angle 0.3s ease-in-out,
+        background-color 0.25s ease,
+        color 0.25s ease,
+        border-color 0.25s ease;
+    border: 0;
+    line-height: 1.2;
+}
+
+
+/* On SB hover, rotate the GH gradient 180°. Combined with SB filling pink
+   at its left edge, the two buttons read as one continuous gradient that
+   has flipped — purple ends up on GH's left, pink in the middle (GH right
+   + SB left), purple back on SB's right. */
+.cta-row:has(.cta-btn--alt:hover) .cta-btn:not(.cta-btn--alt) {
+    --cta-grad-angle: 311deg;
+}
+
+.cta-btn img {
+    filter: brightness(0) invert(1);
+}
+
+.cta-btn:hover {
+    transform: translateY(-2px);
+    color: #fff;
+    box-shadow: 0 8px 18px rgba(74, 47, 189, 0.25);
+}
+
+.cta-btn--alt {
+    background: transparent;
+    color: #4a2fbd;
+    border: 2px solid #4a2fbd;
+    padding: calc(0.7em - 2px) calc(1.4em - 2px);
+    position: relative;
+    overflow: hidden;
+    isolation: isolate;
+}
+
+/* Left-to-right gradient fill on hover. Pink-left, purple-right —
+   continuing the GH gradient as it rotates: GH's right edge becomes pink,
+   SB's left edge picks it up at pink, and SB transitions back to purple
+   at its right. */
+.cta-btn--alt::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 0;
+    height: 100%;
+    background: linear-gradient(131deg, #aa367c 28%, #4a2fbd 71%);
+    transition: width 0.3s ease-in-out;
+    z-index: -1;
+    pointer-events: none;
+}
+
+.cta-btn--alt:hover::before {
+    width: 100%;
+}
+
+.cta-btn--alt img {
+    filter: none;
+}
+
+.cta-btn--alt .sb-icon__inner {
+    fill: #fff;
+    transition: fill 0.3s ease-in-out;
+}
+
+.cta-btn--alt:hover {
+    color: #fff;
+    transform: none;
+    box-shadow: none;
+}
+
+.cta-btn--alt:hover .sb-icon__inner {
+    fill: #aa367c;
+}
+
+.v-screenshot .tech-label {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #3d3a55;
+    margin: 2.5em 0 1em;
+}
+
+.tech-badges {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4em;
+}
+
+.tech-badges li {
+    font-size: 0.72rem;
+    font-weight: 500;
+    letter-spacing: 0.3px;
+    color: #4a2fbd;
+    background: rgba(74, 47, 189, 0.08);
+    padding: 0.28em 0.7em;
+    border-radius: 999px;
+    white-space: nowrap;
+}
+
+.sb-frame {
+    display: block;
+    position: relative;
+    border-radius: 14px;
+    overflow: hidden;
+    text-decoration: none;
+    box-shadow: 0 12px 32px rgba(20, 20, 40, 0.25);
+}
+
+/* SB-chrome wrapper: topbar + sidebar + canvas (iframe inside canvas) */
+.sb-mock {
+    width: 100%;
+    aspect-ratio: 16 / 10;
+    background: #fafafc;
+    border-radius: 12px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.sb-mock__topbar {
+    height: 28px;
+    background: #fff;
+    border-bottom: 1px solid #ececf2;
+    display: flex;
+    align-items: center;
+    padding: 0 0.7em;
+    justify-content: space-between;
+    flex-shrink: 0;
+}
+
+.sb-mock__brand {
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: #ff4785;
+    letter-spacing: 0.3px;
+}
+
+.sb-mock__dots {
+    display: inline-flex;
+    gap: 4px;
+}
+
+.sb-mock__dots i {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #e3e3eb;
+    display: inline-block;
+}
+
+.sb-mock__body {
+    flex: 1;
+    display: flex;
+    min-height: 0;
+}
+
+.sb-mock__sidebar {
+    width: 28%;
+    background: #f6f9fc;
+    padding: 0.8em 0.6em;
+    border-right: 1px solid #ececf2;
+    flex-shrink: 0;
+}
+
+.sb-mock__sidebar-group {
+    margin-bottom: 0.9em;
+}
+
+.sb-mock__sidebar-line {
+    height: 7px;
+    background: #d8dde6;
+    border-radius: 4px;
+    margin: 0.45em 0;
+}
+
+.sb-mock__sidebar-line.w70 { width: 70%; }
+.sb-mock__sidebar-line.w65 { width: 65%; }
+.sb-mock__sidebar-line.w60 { width: 60%; }
+.sb-mock__sidebar-line.w55 { width: 55%; }
+.sb-mock__sidebar-line.w50 { width: 50%; }
+.sb-mock__sidebar-line.w45 { width: 45%; }
+.sb-mock__sidebar-line.active { background: #ff4785; }
+
+.sb-mock__canvas {
+    flex: 1;
+    background: #fafafc;
+    min-width: 0;
+    overflow: hidden;
+    position: relative;
+    display: flex;
+    align-items: stretch;
+    justify-content: stretch;
+    padding: 2% 2.5% 0;
+}
+
+/* The card-in-canvas — the iframe sits inside this lifted white panel with
+   breathing room from the canvas top + sides. The bottom is flush with the
+   canvas edge (no bottom rounding) so the iframe content reaches the floor. */
+.sb-mock__card {
+    flex: 1;
+    background: #fff;
+    border-radius: 8px 8px 0 0;
+    box-shadow: 0 -2px 16px rgba(0, 0, 0, 0.08);
+    overflow: hidden;
+}
+
+/* Iframe renders at a wider virtual viewport (111%) and scales to fit
+   (0.9). Slight zoom-out gives the SB story a touch more horizontal room
+   while staying close to natural size. */
+.sb-mock__iframe {
+    width: 111.11%;
+    height: 111.11%;
+    transform: scale(0.9);
+    transform-origin: 0 0;
+    border: 0;
+    display: block;
+    pointer-events: none;
+    background: #fff;
+}
+
+.sb-frame__overlay {
+    position: absolute;
+    inset: auto 0 0 0;
+    padding: 0.7em;
+    background: linear-gradient(0deg, rgba(0, 0, 0, 0.65) 0%, transparent 100%);
+    color: #fff;
+    text-align: center;
+    font-weight: 600;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+.sb-frame:hover .sb-frame__overlay {
+    opacity: 1;
+}
+
+@media (max-width: 768px) {
+    .v-screenshot__h {
+        text-align: center;
+    }
+    .cta-row--start {
+        justify-content: center;
+    }
+}
+
 
 
 /* ==== Footer ==== */

--- a/src/components/Footer.stories.tsx
+++ b/src/components/Footer.stories.tsx
@@ -1,9 +1,22 @@
+import type { Meta } from '@storybook/react-vite';
 import Footer from './Footer';
 
-const meta = {
+const meta: Meta<typeof Footer> = {
     title: 'Showcase/Sections/Footer',
     component: Footer,
-    parameters: { layout: 'fullscreen', docs: { description: { component: "Page footer — built-with attribution + social icons + copyright. Sits below PreFooter on the live site." } } }
+    decorators: [
+        (Story) => (
+            <div
+                style={{
+                    background: 'linear-gradient(90deg, #5b2a86 0%, #4a6fc7 100%)',
+                    paddingTop: 180
+                }}
+            >
+                <Story />
+            </div>
+        )
+    ],
+    parameters: { layout: 'fullscreen', docs: { description: { component: "Page footer — built-with attribution + social icons + copyright. Sits below PreFooter on the live site. PreFooter has margin-top: -122px to overlap the section above; the decorator adds headroom so the story isn't clipped." } } }
 };
 
 export default meta;

--- a/src/components/MomentumTabs.stories.tsx
+++ b/src/components/MomentumTabs.stories.tsx
@@ -14,9 +14,16 @@ type StoryArgs = {
 
 const meta: Meta<StoryArgs> = {
     title: 'Components/Composites/MomentumTabs',
+    /* MomentumTabs caches its initial indicator measurement in
+       `initializedRef`. Without a story-id key, switching between stories
+       reuses the component instance — useLayoutEffect short-circuits on the
+       stale ref and the indicator stays pinned to the previous story's
+       active button. Keying the wrapper on ctx.id forces a fresh mount per
+       story so the measurement runs again. */
     decorators: [
-        (Story) => (
+        (Story, ctx) => (
             <section
+                key={ctx.id}
                 className="projects"
                 style={{ background: 'var(--almost-black)', padding: '4rem 1rem' }}
             >

--- a/src/components/MomentumTabs.tsx
+++ b/src/components/MomentumTabs.tsx
@@ -57,17 +57,80 @@ const MomentumTabs = <T extends string>({
     // frozen by the initializedRef guard.
     useLayoutEffect(() => {
         if (initializedRef.current || !enabled) return;
-        initializedRef.current = true;
-        const el = buttonRefs.current[active];
-        if (el) {
-            setIndicator({
-                left: el.offsetLeft,
-                top: el.offsetTop,
-                width: el.offsetWidth,
-                height: el.offsetHeight
-            });
-        }
+        // Retry across rAF ticks so we don't lock in a zero-width measurement
+        // when the active button hasn't finished layout (font load, content-
+        // visibility skip, etc.). The init flag only flips once we get a real
+        // box; if all retries fail we leave it false so a future trigger
+        // (resize, active change) can try again.
+        let attempts = 0;
+        const tryMeasure = () => {
+            if (initializedRef.current) return;
+            const el = buttonRefs.current[active];
+            if (el && el.offsetWidth > 0) {
+                initializedRef.current = true;
+                setIndicator({
+                    left: el.offsetLeft,
+                    top: el.offsetTop,
+                    width: el.offsetWidth,
+                    height: el.offsetHeight
+                });
+                return;
+            }
+            if (attempts++ < 5) requestAnimationFrame(tryMeasure);
+        };
+        tryMeasure();
     }, [enabled, active]);
+
+    // Watch the active button for size changes and re-measure on each change.
+    // Catches the cases the rAF retry and fonts.ready don't: any reflow that
+    // happens after initial measurement (slow font swap, content shift, parent
+    // width change). RO fires once immediately on observe with current size,
+    // which doubles as a final correction pass for the initial measurement.
+    useEffect(() => {
+        if (!enabled) return;
+        if (typeof ResizeObserver === 'undefined') return;
+        const el = buttonRefs.current[active];
+        if (!el) return;
+        const ro = new ResizeObserver(() => {
+            if (isAnimatingRef.current) return;
+            if (el.offsetWidth > 0) {
+                setIndicator({
+                    left: el.offsetLeft,
+                    top: el.offsetTop,
+                    width: el.offsetWidth,
+                    height: el.offsetHeight
+                });
+            }
+        });
+        ro.observe(el);
+        return () => ro.disconnect();
+    }, [enabled, active, isAnimatingRef]);
+
+    // Re-measure once web fonts finish loading. The initial useLayoutEffect
+    // can fire while system fallback fonts are still in use, which renders the
+    // active tab slightly smaller than its final size. Without this, the
+    // indicator coords get cached against the fallback-font box and the
+    // perimeter trace ends up offset from the now-bigger active tab.
+    useEffect(() => {
+        if (!enabled) return;
+        if (typeof document === 'undefined' || !document.fonts) return;
+        let cancelled = false;
+        document.fonts.ready.then(() => {
+            if (cancelled || isAnimatingRef.current) return;
+            const el = buttonRefs.current[activeRef.current];
+            if (el && el.offsetWidth > 0) {
+                setIndicator({
+                    left: el.offsetLeft,
+                    top: el.offsetTop,
+                    width: el.offsetWidth,
+                    height: el.offsetHeight
+                });
+            }
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, [enabled, isAnimatingRef]);
 
     // Keep the indicator pinned to the active tab when the viewport resizes.
     // Fade out on first resize tick (gated by ref so setState fires once per

--- a/src/components/PreFooter.tsx
+++ b/src/components/PreFooter.tsx
@@ -1,45 +1,117 @@
-import { Container, Row, Col } from "react-bootstrap";
-import reactIcon from "../assets/images/icons/react-original.svg";
-import bootstrapIcon from "../assets/images/icons/bootstrap-original.svg";
+import { Container, Row, Col } from 'react-bootstrap';
+import githubIcon from '../assets/images/icons/github.svg';
 
-const PreFooter = () => {
-    return (
-        <Container>
-            <Row className="align-items-center">
-                <Col lg={12}>
-                    <div id="built-with" className="built-with">
-                        <h3>
-                            This Site Was <br />
-                            Built With <span>♥️</span> Using:
-                        </h3>
-                        <div className="tooling-icons">
-                            <div className="tooling-icon react-icon">
-                                <img
-                                    src={reactIcon}
-                                    alt="react-icon"
-                                    width={80}
-                                    height={80}
-                                    loading="lazy"
-                                />
-                                <span>React</span>
+const REPO_URL = 'https://github.com/MiguelDotL/migueldotl-portfolio';
+const SB_URL = 'https://migueldotl.github.io/storybook';
+const SB_ITERATION_URL = 'https://migueldotl.github.io/storybook/?path=/story/design-iterations-projecttabs--pill-fill-sliding';
+const SB_IFRAME_URL = 'https://migueldotl.github.io/storybook/iframe.html?id=design-iterations-projecttabs--pill-fill-sliding&viewMode=story';
+
+const TECH = ['React', 'TypeScript', 'Bootstrap', 'Chromatic', 'Vite', 'Vitest'];
+
+const StorybookIcon = () => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 256 319"
+        width="15"
+        height="18"
+        aria-hidden
+    >
+        <path
+            d="M9.022 314.567L.395 16.84A16.819 16.819 0 0 1 16-1.337L237.057.012a16.818 16.818 0 0 1 17.59 16.812v285.44a16.818 16.818 0 0 1-16.142 16.804l-67.2 2.59a8.41 8.41 0 0 1-8.728-8.4v-23.323a4.205 4.205 0 0 0-5.06-4.118c-13.97 3.013-32.137 4.652-50.92 4.652-18.785 0-36.95-1.64-50.922-4.652a4.205 4.205 0 0 0-5.06 4.118v23.864a8.41 8.41 0 0 1-8.671 8.4l-7.052-.232.013-.232c-13.61-.49-25.347-9.84-25.883-23.158z"
+            fill="currentColor"
+        />
+        <path
+            className="sb-icon__inner"
+            d="M170.692 14.86l1.18-29.034 24.298-2.05 1.04 30.953a2.066 2.066 0 0 1-3.328 1.7l-9.382-7.405-11.105 8.428a2.066 2.066 0 0 1-3.31-1.737zm-37.92 102.26c0 6.566 44.236 3.43 50.18-1.182 0-44.776-24.013-68.295-67.95-68.295-43.937 0-68.582 23.886-68.582 59.715 0 62.4 84.214 63.6 84.214 97.685 0 9.572-4.69 15.27-15.013 15.27-13.45 0-18.768-6.87-18.142-30.224 0-5.066-51.376-6.642-52.94 0-3.985 56.578 31.193 72.92 71.708 72.92 39.262 0 70.082-20.916 70.082-58.776 0-66.851-85.467-65.012-85.467-98.171 0-13.484 10.012-15.272 15.952-15.272 6.252 0 17.515 1.103 16.95 26.33z"
+        />
+    </svg>
+);
+
+const PreFooter = () => (
+    <Container>
+        <Row>
+            <Col lg={12}>
+                <div id="built-with" className="built-with v-screenshot">
+                    <Row className="align-items-center g-4">
+                        <Col md={7}>
+                            <a
+                                className="sb-frame"
+                                href={SB_ITERATION_URL}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                aria-label="Open Storybook iteration"
+                            >
+                                <div className="sb-mock">
+                                    <div className="sb-mock__topbar">
+                                        <span className="sb-mock__brand">Storybook</span>
+                                        <span className="sb-mock__dots" aria-hidden>
+                                            <i /><i /><i />
+                                        </span>
+                                    </div>
+                                    <div className="sb-mock__body">
+                                        <div className="sb-mock__sidebar" aria-hidden>
+                                            <div className="sb-mock__sidebar-group">
+                                                <div className="sb-mock__sidebar-line w70" />
+                                                <div className="sb-mock__sidebar-line w50" />
+                                                <div className="sb-mock__sidebar-line w60 active" />
+                                                <div className="sb-mock__sidebar-line w55" />
+                                            </div>
+                                            <div className="sb-mock__sidebar-group">
+                                                <div className="sb-mock__sidebar-line w65" />
+                                                <div className="sb-mock__sidebar-line w45" />
+                                                <div className="sb-mock__sidebar-line w55" />
+                                            </div>
+                                        </div>
+                                        <div className="sb-mock__canvas">
+                                            <div className="sb-mock__card">
+                                                <iframe
+                                                    className="sb-mock__iframe"
+                                                    src={SB_IFRAME_URL}
+                                                    title="Storybook iteration: ProjectTabs"
+                                                    loading="lazy"
+                                                />
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <span className="sb-frame__overlay">View in Storybook →</span>
+                            </a>
+                        </Col>
+                        <Col md={5}>
+                            <h3 className="v-screenshot__h">
+                                Peek <span>under the hood</span>.
+                            </h3>
+                            <p className="lead-copy">
+                                Take a look at{' '}
+                                <a href={REPO_URL} target="_blank" rel="noopener noreferrer">
+                                    the code
+                                </a>
+                                , or learn about my{' '}
+                                <a href={SB_ITERATION_URL} target="_blank" rel="noopener noreferrer">
+                                    iterative design process
+                                </a>{' '}
+                                in Storybook. Tabs, buttons, hover states — each piece went through several ideations before shipping.
+                            </p>
+                            <div className="cta-row cta-row--start cta-row--rect">
+                                <a className="cta-btn" href={REPO_URL} target="_blank" rel="noopener noreferrer">
+                                    <img src={githubIcon} alt="" width={18} height={18} /> The Repo
+                                </a>
+                                <a className="cta-btn cta-btn--alt" href={SB_URL} target="_blank" rel="noopener noreferrer">
+                                    <StorybookIcon /> Storybook
+                                </a>
                             </div>
-                            <span className="plus-sign">+</span>
-                            <div className="tooling-icon bootstrap-icon">
-                                <img
-                                    src={bootstrapIcon}
-                                    alt="bootstrap-icon"
-                                    width={80}
-                                    height={80}
-                                    loading="lazy"
-                                />
-                                <span>Bootstrap</span>
-                            </div>
-                        </div>
-                    </div>
-                </Col>
-            </Row>
-        </Container>
-    );
-};
+                            <p className="tech-label">Built with</p>
+                            <ul className="tech-badges">
+                                {TECH.map((t) => (
+                                    <li key={t}>{t}</li>
+                                ))}
+                            </ul>
+                        </Col>
+                    </Row>
+                </div>
+            </Col>
+        </Row>
+    </Container>
+);
 
 export default PreFooter;

--- a/src/components/PreFooterExploration.stories.css
+++ b/src/components/PreFooterExploration.stories.css
@@ -1,0 +1,431 @@
+/* === Shared === */
+.tech-badges {
+    list-style: none;
+    padding: 0;
+    margin: 1.4em 0 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5em;
+    justify-content: center;
+}
+
+.tech-badges li {
+    font-size: 0.78rem;
+    font-weight: 500;
+    letter-spacing: 0.4px;
+    color: #4a2fbd;
+    background: rgba(74, 47, 189, 0.08);
+    padding: 0.32em 0.85em;
+    border-radius: 999px;
+}
+
+/* Mock Storybook screenshot */
+.sb-mock {
+    width: 100%;
+    aspect-ratio: 16 / 10;
+    background: #fafafc;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 12px 32px rgba(20, 20, 40, 0.25);
+    display: flex;
+    flex-direction: column;
+}
+
+.sb-mock__topbar {
+    height: 28px;
+    background: #fff;
+    border-bottom: 1px solid #ececf2;
+    display: flex;
+    align-items: center;
+    padding: 0 0.7em;
+    justify-content: space-between;
+}
+
+.sb-mock__brand {
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: #ff4785;
+    letter-spacing: 0.3px;
+}
+
+.sb-mock__dots {
+    display: inline-flex;
+    gap: 4px;
+}
+
+.sb-mock__dots i {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #e3e3eb;
+    display: inline-block;
+}
+
+.sb-mock__body {
+    flex: 1;
+    display: flex;
+    min-height: 0;
+}
+
+.sb-mock__sidebar {
+    width: 28%;
+    background: #f6f9fc;
+    padding: 0.8em 0.6em;
+    border-right: 1px solid #ececf2;
+}
+
+.sb-mock__sidebar-group {
+    margin-bottom: 0.9em;
+}
+
+.sb-mock__sidebar-line {
+    height: 7px;
+    background: #d8dde6;
+    border-radius: 4px;
+    margin: 0.45em 0;
+}
+
+.sb-mock__sidebar-line.w70 { width: 70%; }
+.sb-mock__sidebar-line.w65 { width: 65%; }
+.sb-mock__sidebar-line.w60 { width: 60%; }
+.sb-mock__sidebar-line.w55 { width: 55%; }
+.sb-mock__sidebar-line.w50 { width: 50%; }
+.sb-mock__sidebar-line.w45 { width: 45%; }
+.sb-mock__sidebar-line.active { background: #ff4785; }
+
+.sb-mock__canvas {
+    flex: 1;
+    padding: 1em;
+    background: #fafafc;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.sb-mock__card {
+    background: #fff;
+    width: 70%;
+    height: 70%;
+    border-radius: 10px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+}
+
+/* === A. Twin Link Cards === */
+.v-twin h3 {
+    margin-bottom: 1.1em;
+}
+
+.twin-cards {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1em;
+    max-width: 640px;
+    margin: 0 auto;
+}
+
+.twin-card {
+    display: flex;
+    align-items: center;
+    gap: 1em;
+    background: #f7f7fb;
+    border: 1px solid #ebeaf3;
+    border-radius: 16px;
+    padding: 1em 1.2em;
+    text-decoration: none;
+    color: var(--almost-black);
+    transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.twin-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 24px rgba(74, 47, 189, 0.14);
+    border-color: #c8c0eb;
+    color: var(--almost-black);
+}
+
+.twin-card img {
+    width: 48px;
+    height: 48px;
+    flex-shrink: 0;
+}
+
+.twin-card__sb {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    border-radius: 10px;
+    background: #ff4785;
+    color: #fff;
+    font-weight: 800;
+    font-size: 1rem;
+    flex-shrink: 0;
+}
+
+.twin-card strong {
+    display: block;
+    font-weight: 700;
+    font-size: 1rem;
+    line-height: 1.2;
+}
+
+.twin-card span {
+    display: block;
+    font-size: 0.85rem;
+    color: #6e6c80;
+    margin-top: 0.1em;
+}
+
+/* === B. CTAs Below Stack === */
+.v-ctas .cta-row {
+    margin-top: 1.4em;
+}
+
+/* === Exploration-only CTA modifiers (base styles live in Footer.css) === */
+
+.cta-btn--alt-tint-purple {
+    background: rgba(74, 47, 189, 0.08);
+}
+
+.cta-btn--alt-tint-pink {
+    background: rgba(255, 71, 133, 0.08);
+}
+
+.cta-btn--alt-card {
+    background: #fff;
+    border-color: transparent;
+    box-shadow: 0 4px 14px rgba(74, 47, 189, 0.15);
+}
+
+.cta-btn--alt-card:hover {
+    box-shadow: 0 8px 22px rgba(74, 47, 189, 0.25);
+}
+
+/* Button shape modifier — comparison-only (rect lives in Footer.css now) */
+.cta-row--rect-soft .cta-btn {
+    border-radius: 4px;
+}
+
+.cta-btn--ghost {
+    background: transparent;
+    color: var(--almost-black);
+    border: 1px solid #d8d8e3;
+    padding: calc(0.7em - 1px) calc(1.4em - 1px);
+}
+
+.cta-btn--ghost img {
+    filter: none;
+}
+
+.cta-btn--ghost:hover {
+    color: var(--almost-black);
+    background: #f3f3f8;
+    box-shadow: none;
+}
+
+/* === C. Screenshot Feature === */
+.v-screenshot {
+    padding: 32px 32px 28px;
+}
+
+.v-screenshot__h {
+    text-align: left;
+    margin-bottom: 1em;
+}
+
+.built-with .lead-copy {
+    color: var(--mid-grey);
+    font-size: 0.95rem;
+    line-height: 1.55;
+    margin-bottom: 1.5em;
+}
+
+.built-with .lead-copy a {
+    background: linear-gradient(131deg, #aa367c 28%, #4a2fbd 71%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+    font-weight: 600;
+    text-decoration: underline;
+    text-decoration-color: #aa367c;
+    text-underline-offset: 2px;
+    text-decoration-thickness: 1.5px;
+    transition: text-decoration-thickness 0.15s ease, text-decoration-color 0.15s ease;
+}
+
+.built-with .lead-copy a:hover {
+    text-decoration-color: #4a2fbd;
+    text-decoration-thickness: 2.5px;
+}
+
+.v-screenshot .tech-badges {
+    justify-content: flex-start;
+    margin-top: 0;
+}
+
+.v-screenshot .tech-label {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #3d3a55;
+    margin: 2.5em 0 1em;
+}
+
+.sb-frame {
+    display: block;
+    position: relative;
+    border-radius: 14px;
+    overflow: hidden;
+    text-decoration: none;
+}
+
+.sb-frame__overlay {
+    position: absolute;
+    inset: auto 0 0 0;
+    padding: 0.7em;
+    background: linear-gradient(0deg, rgba(0, 0, 0, 0.65) 0%, transparent 100%);
+    color: #fff;
+    text-align: center;
+    font-weight: 600;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+.sb-frame:hover .sb-frame__overlay {
+    opacity: 1;
+}
+
+/* === D. Stacked Strip === */
+.v-strip {
+    text-align: center;
+}
+
+.v-strip h3 {
+    margin: 0.6em 0 1em;
+}
+
+.v-strip .tech-badges {
+    margin: 0 0 0.4em;
+}
+
+.pill-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.8em;
+    flex-wrap: wrap;
+}
+
+.pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5em;
+    padding: 0.85em 1.5em;
+    border-radius: 999px;
+    font-weight: 600;
+    text-decoration: none;
+    background: var(--almost-black);
+    color: #fff;
+    transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.pill img {
+    filter: brightness(0) invert(1);
+}
+
+.pill:hover {
+    transform: translateY(-2px);
+    color: #fff;
+    box-shadow: 0 10px 22px rgba(0, 0, 0, 0.18);
+}
+
+.pill--alt {
+    background: linear-gradient(131deg, #aa367c 28%, #4a2fbd 71%);
+}
+
+/* === E. Single Feature Card === */
+.v-single {
+    padding: 32px;
+}
+
+.feature-grid {
+    display: grid;
+    grid-template-columns: 3fr 2fr;
+    gap: 1.6em;
+    align-items: center;
+}
+
+.feature-card {
+    display: block;
+    border-radius: 14px;
+    overflow: hidden;
+    text-decoration: none;
+    color: var(--almost-black);
+    box-shadow: 0 12px 28px rgba(20, 20, 40, 0.14);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.feature-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 18px 36px rgba(74, 47, 189, 0.2);
+    color: var(--almost-black);
+}
+
+.feature-card__body {
+    background: #fff;
+    padding: 0.9em 1.1em;
+    border-top: 1px solid #f0eef6;
+}
+
+.feature-card__body strong {
+    display: block;
+    font-weight: 700;
+}
+
+.feature-card__body span {
+    display: block;
+    font-size: 0.85rem;
+    color: #6e6c80;
+}
+
+.feature-side {
+    display: flex;
+    flex-direction: column;
+    gap: 1em;
+    align-items: flex-start;
+}
+
+.feature-side__h {
+    text-align: left;
+    margin: 0;
+}
+
+.feature-side .tech-badges {
+    margin: 0;
+    justify-content: flex-start;
+}
+
+/* === Responsive === */
+@media (max-width: 768px) {
+    .twin-cards {
+        grid-template-columns: 1fr;
+    }
+    .feature-grid {
+        grid-template-columns: 1fr;
+    }
+    .v-screenshot__h,
+    .feature-side__h {
+        text-align: center;
+    }
+    .cta-row--start {
+        justify-content: center;
+    }
+    .feature-side {
+        align-items: center;
+    }
+    .feature-side .tech-badges {
+        justify-content: center;
+    }
+}

--- a/src/components/PreFooterExploration.stories.tsx
+++ b/src/components/PreFooterExploration.stories.tsx
@@ -1,0 +1,447 @@
+import type { Meta } from '@storybook/react-vite';
+import { Container, Row, Col } from 'react-bootstrap';
+import '../assets/styles/Footer.css';
+import './PreFooterExploration.stories.css';
+
+import reactIcon from '../assets/images/icons/react-original.svg';
+import bootstrapIcon from '../assets/images/icons/bootstrap-original.svg';
+import githubIcon from '../assets/images/icons/github.svg';
+
+const REPO_URL = 'https://github.com/MiguelDotL/migueldotl-portfolio';
+const SB_URL = 'https://migueldotl.github.io/storybook';
+const SB_ITERATION_URL = 'https://migueldotl.github.io/storybook/?path=/story/design-iterations-projecttabs--pill-fill-sliding';
+const TECH = ['React', 'TypeScript', 'Bootstrap', 'Chromatic', 'Vite', 'Vitest'];
+
+const meta: Meta = {
+    title: 'Design Iterations/PreFooter',
+    decorators: [
+        (Story) => (
+            <footer
+                className="footer"
+                style={{
+                    background: 'linear-gradient(90deg, #5b2a86 0%, #4a6fc7 100%)',
+                    padding: '180px 0 2rem'
+                }}
+            >
+                <Story />
+            </footer>
+        )
+    ],
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    "Design exploration for the PreFooter section. Five layout variants plus stacked headline-comparison stories for the variants where copy is being iterated. Mock Storybook screenshots are CSS placeholders — replace with a real PNG once a direction is picked."
+            }
+        }
+    }
+};
+
+export default meta;
+
+const TechBadges = ({ items = TECH }: { items?: readonly string[] }) => (
+    <ul className="tech-badges">
+        {items.map((t) => (
+            <li key={t}>{t}</li>
+        ))}
+    </ul>
+);
+
+const StorybookIcon = () => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 256 319"
+        width="15"
+        height="18"
+        aria-hidden
+    >
+        <path
+            d="M9.022 314.567L.395 16.84A16.819 16.819 0 0 1 16-1.337L237.057.012a16.818 16.818 0 0 1 17.59 16.812v285.44a16.818 16.818 0 0 1-16.142 16.804l-67.2 2.59a8.41 8.41 0 0 1-8.728-8.4v-23.323a4.205 4.205 0 0 0-5.06-4.118c-13.97 3.013-32.137 4.652-50.92 4.652-18.785 0-36.95-1.64-50.922-4.652a4.205 4.205 0 0 0-5.06 4.118v23.864a8.41 8.41 0 0 1-8.671 8.4l-7.052-.232.013-.232c-13.61-.49-25.347-9.84-25.883-23.158z"
+            fill="currentColor"
+        />
+        <path
+            className="sb-icon__inner"
+            d="M170.692 14.86l1.18-29.034 24.298-2.05 1.04 30.953a2.066 2.066 0 0 1-3.328 1.7l-9.382-7.405-11.105 8.428a2.066 2.066 0 0 1-3.31-1.737zm-37.92 102.26c0 6.566 44.236 3.43 50.18-1.182 0-44.776-24.013-68.295-67.95-68.295-43.937 0-68.582 23.886-68.582 59.715 0 62.4 84.214 63.6 84.214 97.685 0 9.572-4.69 15.27-15.013 15.27-13.45 0-18.768-6.87-18.142-30.224 0-5.066-51.376-6.642-52.94 0-3.985 56.578 31.193 72.92 71.708 72.92 39.262 0 70.082-20.916 70.082-58.776 0-66.851-85.467-65.012-85.467-98.171 0-13.484 10.012-15.272 15.952-15.272 6.252 0 17.515 1.103 16.95 26.33z"
+        />
+    </svg>
+);
+
+const SbMock = () => (
+    <div className="sb-mock" aria-hidden>
+        <div className="sb-mock__topbar">
+            <span className="sb-mock__brand">Storybook</span>
+            <span className="sb-mock__dots">
+                <i /><i /><i />
+            </span>
+        </div>
+        <div className="sb-mock__body">
+            <div className="sb-mock__sidebar">
+                <div className="sb-mock__sidebar-group">
+                    <div className="sb-mock__sidebar-line w70" />
+                    <div className="sb-mock__sidebar-line w50" />
+                    <div className="sb-mock__sidebar-line w60 active" />
+                    <div className="sb-mock__sidebar-line w55" />
+                </div>
+                <div className="sb-mock__sidebar-group">
+                    <div className="sb-mock__sidebar-line w65" />
+                    <div className="sb-mock__sidebar-line w45" />
+                    <div className="sb-mock__sidebar-line w55" />
+                </div>
+            </div>
+            <div className="sb-mock__canvas">
+                <div className="sb-mock__card" />
+            </div>
+        </div>
+    </div>
+);
+
+// Original — the pre-redesign "Built With React + Bootstrap" layout, preserved as reference.
+export const OriginalLayout = () => (
+    <Container>
+        <Row className="align-items-center">
+            <Col lg={12}>
+                <div className="built-with">
+                    <h3>
+                        This Site Was <br />
+                        Built With <span>♥️</span> Using:
+                    </h3>
+                    <div className="tooling-icons">
+                        <div className="tooling-icon react-icon">
+                            <img src={reactIcon} alt="react-icon" width={80} height={80} loading="lazy" />
+                            <span>React</span>
+                        </div>
+                        <span className="plus-sign">+</span>
+                        <div className="tooling-icon bootstrap-icon">
+                            <img src={bootstrapIcon} alt="bootstrap-icon" width={80} height={80} loading="lazy" />
+                            <span>Bootstrap</span>
+                        </div>
+                    </div>
+                </div>
+            </Col>
+        </Row>
+    </Container>
+);
+
+// A. Twin Link Cards — two link cards replace the React/Bootstrap pair
+export const TwinLinkCards = () => (
+    <Container>
+        <Row className="align-items-center">
+            <Col lg={12}>
+                <div className="built-with v-twin">
+                    <h3>
+                        Curious how it&rsquo;s <span>built</span>?
+                    </h3>
+                    <div className="twin-cards">
+                        <a className="twin-card" href={REPO_URL} target="_blank" rel="noopener noreferrer">
+                            <img src={githubIcon} alt="" width={48} height={48} loading="lazy" />
+                            <div>
+                                <strong>Source Code</strong>
+                                <span>Browse the repo on GitHub</span>
+                            </div>
+                        </a>
+                        <a className="twin-card" href={SB_URL} target="_blank" rel="noopener noreferrer">
+                            <span className="twin-card__sb" aria-hidden>SB</span>
+                            <div>
+                                <strong>Component Library</strong>
+                                <span>Explore in Storybook</span>
+                            </div>
+                        </a>
+                    </div>
+                    <TechBadges />
+                </div>
+            </Col>
+        </Row>
+    </Container>
+);
+
+// B. CTAs Below the existing tech stack — most conservative
+export const CTAsBelowStack = () => (
+    <Container>
+        <Row className="align-items-center">
+            <Col lg={12}>
+                <div className="built-with v-ctas">
+                    <h3>
+                        This Site Was <br />
+                        Built With <span>♥️</span> Using:
+                    </h3>
+                    <div className="tooling-icons">
+                        <div className="tooling-icon">
+                            <img src={reactIcon} alt="" width={80} height={80} loading="lazy" />
+                            <span>React</span>
+                        </div>
+                        <span className="plus-sign">+</span>
+                        <div className="tooling-icon">
+                            <img src={bootstrapIcon} alt="" width={80} height={80} loading="lazy" />
+                            <span>Bootstrap</span>
+                        </div>
+                    </div>
+                    <div className="cta-row">
+                        <a className="cta-btn" href={REPO_URL} target="_blank" rel="noopener noreferrer">
+                            <img src={githubIcon} alt="" width={18} height={18} /> View Source
+                        </a>
+                        <a className="cta-btn cta-btn--alt" href={SB_URL} target="_blank" rel="noopener noreferrer">
+                            Component Library
+                        </a>
+                    </div>
+                </div>
+            </Col>
+        </Row>
+    </Container>
+);
+
+// === C. Screenshot Feature — split layout, screenshot left, copy + CTA right ===
+
+type ScreenshotBodyProps = {
+    heading?: React.ReactNode;
+    leadCopy?: React.ReactNode;
+    tech?: readonly string[];
+    sbButtonClass?: string;
+    ctaRowClass?: string;
+    compact?: boolean;
+};
+
+const DEFAULT_LEAD_COPY = (
+    <>
+        Take a look at{' '}
+        <a href={REPO_URL} target="_blank" rel="noopener noreferrer">
+            the code
+        </a>
+        , or learn about my{' '}
+        <a href={SB_ITERATION_URL} target="_blank" rel="noopener noreferrer">
+            iterative design process
+        </a>{' '}
+        in Storybook. Tabs, buttons, hover states — each piece went through several ideations before shipping.
+    </>
+);
+
+const ScreenshotFeatureBody = ({
+    heading,
+    leadCopy = DEFAULT_LEAD_COPY,
+    tech,
+    sbButtonClass = 'cta-btn cta-btn--alt',
+    ctaRowClass = 'cta-row cta-row--start',
+    compact
+}: ScreenshotBodyProps) => (
+    <Container>
+        <Row>
+            <Col lg={12}>
+                <div
+                    className="built-with v-screenshot"
+                    style={compact ? { marginTop: 0, marginBottom: 0 } : undefined}
+                >
+                    <Row className="align-items-center g-4">
+                        <Col md={7}>
+                            <a className="sb-frame" href={SB_URL} target="_blank" rel="noopener noreferrer" aria-label="Open Storybook">
+                                <SbMock />
+                                <span className="sb-frame__overlay">View Storybook →</span>
+                            </a>
+                        </Col>
+                        <Col md={5}>
+                            {heading && <h3 className="v-screenshot__h">{heading}</h3>}
+                            <p className="lead-copy">{leadCopy}</p>
+                            <div className={ctaRowClass}>
+                                <a className="cta-btn" href={REPO_URL} target="_blank" rel="noopener noreferrer">
+                                    <img src={githubIcon} alt="" width={18} height={18} /> The Repo
+                                </a>
+                                <a className={sbButtonClass} href={SB_URL} target="_blank" rel="noopener noreferrer">
+                                    <StorybookIcon /> Storybook
+                                </a>
+                            </div>
+                            <p className="tech-label">Built with</p>
+                            <TechBadges items={tech} />
+                        </Col>
+                    </Row>
+                </div>
+            </Col>
+        </Row>
+    </Container>
+);
+
+export const ScreenshotFeature = () => (
+    <ScreenshotFeatureBody heading={<>Peek <span>under the hood</span>.</>} />
+);
+
+// D. Stacked Strip — tech, heading, pills
+export const StackedStrip = () => (
+    <Container>
+        <Row>
+            <Col lg={12}>
+                <div className="built-with v-strip">
+                    <TechBadges />
+                    <h3>
+                        This portfolio is <span>open source</span>.
+                    </h3>
+                    <div className="pill-row">
+                        <a className="pill" href={REPO_URL} target="_blank" rel="noopener noreferrer">
+                            <img src={githubIcon} alt="" width={20} height={20} /> Source on GitHub
+                        </a>
+                        <a className="pill pill--alt" href={SB_URL} target="_blank" rel="noopener noreferrer">
+                            Component Library →
+                        </a>
+                    </div>
+                </div>
+            </Col>
+        </Row>
+    </Container>
+);
+
+// === E. Single Feature Card — SB screenshot is the hero ===
+
+type SingleBodyProps = { heading?: React.ReactNode; compact?: boolean };
+
+const SingleFeatureCardBody = ({ heading, compact }: SingleBodyProps) => (
+    <Container>
+        <Row>
+            <Col lg={12}>
+                <div
+                    className="built-with v-single"
+                    style={compact ? { marginTop: 0, marginBottom: 0 } : undefined}
+                >
+                    <div className="feature-grid">
+                        <a className="feature-card" href={SB_URL} target="_blank" rel="noopener noreferrer">
+                            <SbMock />
+                            <div className="feature-card__body">
+                                <strong>Component Library</strong>
+                                <span>Open in Storybook →</span>
+                            </div>
+                        </a>
+                        <div className="feature-side">
+                            {heading && <h3 className="feature-side__h">{heading}</h3>}
+                            <a className="cta-btn cta-btn--ghost" href={REPO_URL} target="_blank" rel="noopener noreferrer">
+                                <img src={githubIcon} alt="" width={18} height={18} /> Source on GitHub
+                            </a>
+                            <TechBadges />
+                        </div>
+                    </div>
+                </div>
+            </Col>
+        </Row>
+    </Container>
+);
+
+export const SingleFeatureCard = () => (
+    <SingleFeatureCardBody heading={<>How it&rsquo;s <span>built</span>.</>} />
+);
+
+// === Headline iteration: rendered comparisons for variants C and E ===
+
+const HEADLINES: Array<{ label: string; heading: React.ReactNode | undefined }> = [
+    { label: 'Peek under the hood', heading: <>Peek <span>under the hood</span>.</> },
+    { label: 'Behind the scenes', heading: <>Behind the <span>scenes</span>.</> },
+    { label: "How it's built", heading: <>How it&rsquo;s <span>built</span>.</> },
+    { label: 'See the components', heading: <>See the <span>components</span>.</> },
+    { label: 'No heading', heading: undefined }
+];
+
+const ComparisonLabel = ({ children }: { children: React.ReactNode }) => (
+    <p
+        style={{
+            color: '#fff',
+            textAlign: 'center',
+            fontWeight: 600,
+            fontSize: 12,
+            letterSpacing: 1.5,
+            textTransform: 'uppercase',
+            margin: '2.5rem 0 1rem',
+            opacity: 0.85
+        }}
+    >
+        {children}
+    </p>
+);
+
+export const ScreenshotFeatureHeadlines = () => (
+    <>
+        {HEADLINES.map(({ label, heading }) => (
+            <div key={label}>
+                <ComparisonLabel>{label}</ComparisonLabel>
+                <ScreenshotFeatureBody heading={heading} compact />
+            </div>
+        ))}
+    </>
+);
+
+export const SingleFeatureCardHeadlines = () => (
+    <>
+        {HEADLINES.map(({ label, heading }) => (
+            <div key={label}>
+                <ComparisonLabel>{label}</ComparisonLabel>
+                <SingleFeatureCardBody heading={heading} compact />
+            </div>
+        ))}
+    </>
+);
+
+const PICKED_HEADING = <>Peek <span>under the hood</span>.</>;
+
+// === Tech-stack iteration for the Screenshot Feature variant ===
+
+const TECH_STACKS: Array<{ label: string; items: readonly string[] }> = [
+    {
+        label: '8 — full story (default)',
+        items: ['React', 'TypeScript', 'Vite', 'React Bootstrap', 'Storybook', 'Vitest', 'Testing Library', 'Chromatic']
+    },
+    {
+        label: '6 — lean',
+        items: ['React', 'TypeScript', 'Vite', 'React Bootstrap', 'Storybook', 'Vitest']
+    },
+    {
+        label: '5 — most curated',
+        items: ['React', 'TypeScript', 'Vite', 'Storybook', 'Vitest']
+    },
+    {
+        label: '10 — verbose',
+        items: ['React', 'TypeScript', 'Vite', 'React Bootstrap', 'Storybook', 'Vitest', 'Testing Library', 'Chromatic', 'ESLint', 'PurgeCSS']
+    }
+];
+
+export const ScreenshotFeatureTechStacks = () => (
+    <>
+        {TECH_STACKS.map(({ label, items }) => (
+            <div key={label}>
+                <ComparisonLabel>{label}</ComparisonLabel>
+                <ScreenshotFeatureBody heading={PICKED_HEADING} tech={items} compact />
+            </div>
+        ))}
+    </>
+);
+
+// === Storybook button background iteration ===
+
+const SB_BUTTON_BG_VARIANTS: Array<{ label: string; className: string }> = [
+    { label: 'Current — transparent', className: 'cta-btn cta-btn--alt' },
+    { label: 'Chip-tinted purple', className: 'cta-btn cta-btn--alt cta-btn--alt-tint-purple' },
+    { label: 'Pink tint', className: 'cta-btn cta-btn--alt cta-btn--alt-tint-pink' },
+    { label: 'White card with shadow', className: 'cta-btn cta-btn--alt cta-btn--alt-card' }
+];
+
+export const ScreenshotFeatureSbButtonBg = () => (
+    <>
+        {SB_BUTTON_BG_VARIANTS.map(({ label, className }) => (
+            <div key={label}>
+                <ComparisonLabel>{label}</ComparisonLabel>
+                <ScreenshotFeatureBody heading={PICKED_HEADING} sbButtonClass={className} compact />
+            </div>
+        ))}
+    </>
+);
+
+// === Button shape iteration — pill vs rectangular ===
+
+const BTN_SHAPES: Array<{ label: string; className: string }> = [
+    { label: 'Pill — current (999px)', className: 'cta-row cta-row--start' },
+    { label: 'Sharp rectangle — matches Contact form (0)', className: 'cta-row cta-row--start cta-row--rect' },
+    { label: 'Soft rectangle (4px)', className: 'cta-row cta-row--start cta-row--rect-soft' }
+];
+
+export const ScreenshotFeatureBtnShape = () => (
+    <>
+        {BTN_SHAPES.map(({ label, className }) => (
+            <div key={label}>
+                <ComparisonLabel>{label}</ComparisonLabel>
+                <ScreenshotFeatureBody heading={PICKED_HEADING} ctaRowClass={className} compact />
+            </div>
+        ))}
+    </>
+);

--- a/src/components/ProjectTabsExploration.stories.tsx
+++ b/src/components/ProjectTabsExploration.stories.tsx
@@ -78,7 +78,7 @@ const PillFillSlidingVariant = () => {
     return (
         <SectionWrap>
             <h3 style={{ color: 'var(--light-grey)', marginBottom: '1em' }}>
-                Pill-fill rubber — gradient pill stretches across source+target then contracts to target
+                Rubber Pill-Fill — the gradient pill rubber-bands across both tabs before settling on the new one.
             </h3>
             <div
                 style={{
@@ -189,7 +189,7 @@ const UnderlineVariant = () => {
     return (
         <SectionWrap>
             <h3 style={{ color: 'var(--light-grey)', marginBottom: '1em' }}>
-                Underline — bold, grey/white, stretch-and-contract slide
+                Underline slide — a thick line under the active tab stretches across to the new one, then contracts to fit. Classic and minimal, but loses the gradient shape.
             </h3>
             <div
                 ref={containerRef}
@@ -396,7 +396,7 @@ const MomentumTraceVariant = () => {
     return (
         <SectionWrap>
             <h3 style={{ color: 'var(--light-grey)', marginBottom: '1em' }}>
-                Momentum trace — rubber underline slide + directional perimeter wrap; forward retract on continued momentum, reverse retract on directional shift
+                Momentum trace — the rubber underline slide, and a thin line that traces around the active tab in the direction you&rsquo;re moving. Reverse direction and the trace rewinds. The version that ultimately shipped.
             </h3>
             <div
                 ref={containerRef}
@@ -524,7 +524,7 @@ const BigTextVariant = () => {
     return (
         <SectionWrap>
             <h3 style={{ color: 'var(--light-grey)', marginBottom: '1em' }}>
-                Big-text — Featured centered, activation cascades through intermediate tabs
+                Big-text cascade — no indicator at all. Tabs are large titles, the active one centered. Click a non-adjacent tab and the highlight cascades through the in-between ones. Editorial feel.
             </h3>
             <div
                 style={{
@@ -571,7 +571,7 @@ const BigTextVariant = () => {
 const StackedSectionsVariant = () => (
     <SectionWrap>
         <h3 style={{ color: 'var(--light-grey)', marginBottom: '1em' }}>
-            No tabs — stacked sections (everything visible, no clicking)
+            No tabs at all — drops the navigation pattern. Every project group is its own section, top to bottom. Zero clicking, but loses the side-by-side comparison framing.
         </h3>
         {TABS.map((tab) => (
             <div key={tab} style={{ marginBottom: '3em' }}>


### PR DESCRIPTION
## Summary
Promotes the latest dev work to production:

- **#170** — PreFooter "Peek under the hood" redesign + MomentumTabs first-paint init fixes (closes #168, #169)
- **#172** — Footer Storybook story decorator headroom fix (closes #171)

## Test plan
- [x] All commits already passed pre-push hook (lint + tsc + 88 unit tests)
- [x] Visual spot-check on Footer story (locally verified)
- [ ] Post-merge: deploy main → migueldotl.github.io