### PR TITLE
chore: add coverage script + record audit baseline

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
+    "coverage": "vitest run --coverage",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "e2e": "playwright test",


### PR DESCRIPTION
## Summary
- Adds \`"coverage": "vitest run --coverage"\` to package.json. \`@vitest/coverage-v8\` was already installed.
- Captures the unit-project baseline for the audit roadmap; flags real gap files for the B2 ticket.

Closes #174

## Baseline (unit project)

| Metric | Value |
|---|---|
| Statements | 74.14% (545/735) |
| Branches | 63.24% (265/419) |
| Functions | 70.81% (131/185) |
| Lines | 76.64% (502/655) |

Cached memory snapshot claimed 88.9% / 79.78% — that number was stale.

## Heads-up: discovered 11 axe failures in storybook project

Running \`npm run coverage\` (no \`--project\` filter) currently fails on 11 storybook a11y violations introduced by #170. All same root cause: \`.sb-mock__brand\` element renders Storybook pink \`#ff4785\` on white, contrast 3.23:1 (needs 4.5:1). Sites:

- src/components/PreFooter.tsx (1 instance — live PreFooter)
- src/components/PreFooterExploration.stories.tsx (3 + iteration variants)

Pre-push gate doesn't catch these because it runs \`vitest run\` without the storybook browser project. Filing as a separate fix ticket — out of scope for this measurement PR.

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — 88/88 unit tests pass (pre-push gate)
- [x] \`npx vitest run --project unit --coverage\` runs and produces \`coverage/index.html\`