### PR TITLE
fix(prefooter): edge alignment + hover lift + padding tweak

### DIFF
--- a/src/assets/styles/Footer.css
+++ b/src/assets/styles/Footer.css
@@ -77,7 +77,7 @@
 /* === New layout: split screenshot + copy === */
 
 .built-with.v-screenshot {
-    padding: 32px 32px 28px;
+    padding: 32px 34px;
 }
 
 .v-screenshot__h {

--- a/src/assets/styles/Footer.css
+++ b/src/assets/styles/Footer.css
@@ -247,6 +247,12 @@
     overflow: hidden;
     text-decoration: none;
     box-shadow: 0 12px 32px rgba(20, 20, 40, 0.25);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.sb-frame:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 18px 40px rgba(20, 20, 40, 0.35);
 }
 
 /* SB-chrome wrapper: topbar + sidebar + canvas (iframe inside canvas) */

--- a/src/assets/styles/Footer.css
+++ b/src/assets/styles/Footer.css
@@ -8,6 +8,16 @@
     position: relative;
 }
 
+/* At md+, .contact form drops its `margin: 0 1em` (Contact.css media query),
+   so the textarea extends 16px further right than at small viewports. Pull
+   the card 8px past the col-lg-12 content box on each side to match. */
+@media (min-width: 768px) {
+    .built-with {
+        margin-left: -0.5em;
+        margin-right: -0.5em;
+    }
+}
+
 .built-with h3 {
     font-weight: 700;
     letter-spacing: 0.5px;

--- a/src/assets/styles/Footer.css
+++ b/src/assets/styles/Footer.css
@@ -4,7 +4,7 @@
     border-radius: 39px;
     color: var(--almost-black);
     padding: 40px 40px 30px;
-    margin: -122px 1em 80px;
+    margin: -122px 0.5em 80px;
     position: relative;
 }
 

--- a/src/assets/styles/Footer.css
+++ b/src/assets/styles/Footer.css
@@ -4,7 +4,7 @@
     border-radius: 39px;
     color: var(--almost-black);
     padding: 40px 40px 30px;
-    margin: -122px auto 80px;
+    margin: -122px 1em 80px;
     position: relative;
 }
 


### PR DESCRIPTION
## Summary
- **Edge alignment** — \`.built-with\` margin is 0.5em below md (matches form's \`margin: 0 1em\`) and -0.5em at md+ (where form drops to \`margin: 0\` and textarea extends further right via row gutter + col-px-1).
- **Hover lift** — \`.sb-frame\` gets translateY(-4px) + stronger shadow on hover, 0.2s ease.
- **Interior padding** — \`.built-with.v-screenshot\` 32px 32px 28px → 32px 34px.

Closes #179

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — 88/88 pass
- [x] Visual: card right edge aligns with textarea outer edge at desktop; lift transition smooth on hover