### PR TITLE
chore: merge dev → main — prefooter card alignment + hover

### DIFF
--- a/src/assets/styles/Footer.css
+++ b/src/assets/styles/Footer.css
@@ -4,8 +4,18 @@
     border-radius: 39px;
     color: var(--almost-black);
     padding: 40px 40px 30px;
-    margin: -122px auto 80px;
+    margin: -122px 0.5em 80px;
     position: relative;
+}
+
+/* At md+, .contact form drops its `margin: 0 1em` (Contact.css media query),
+   so the textarea extends 16px further right than at small viewports. Pull
+   the card 8px past the col-lg-12 content box on each side to match. */
+@media (min-width: 768px) {
+    .built-with {
+        margin-left: -0.5em;
+        margin-right: -0.5em;
+    }
 }
 
 .built-with h3 {
@@ -67,7 +77,7 @@
 /* === New layout: split screenshot + copy === */
 
 .built-with.v-screenshot {
-    padding: 32px 32px 28px;
+    padding: 32px 34px;
 }
 
 .v-screenshot__h {
@@ -247,6 +257,12 @@
     overflow: hidden;
     text-decoration: none;
     box-shadow: 0 12px 32px rgba(20, 20, 40, 0.25);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.sb-frame:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 18px 40px rgba(20, 20, 40, 0.35);
 }
 
 /* SB-chrome wrapper: topbar + sidebar + canvas (iframe inside canvas) */


### PR DESCRIPTION
## Summary
- **#180** — PreFooter card right edge tracks textarea responsively, .sb-frame hover lift, .v-screenshot interior padding 32px 34px (closes #179)

PR #175 (coverage script + audit baseline) is still open against \`dev\` — not in this batch.