### PR TITLE
chore: merge dev → main — mobile polish + effects library

### DIFF
--- a/src/Welcome.mdx
+++ b/src/Welcome.mdx
@@ -1,0 +1,30 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Welcome" />
+
+# migueldotl-portfolio — Storybook
+
+Component library + design system for [migueldotl-portfolio](https://github.com/MiguelDotL/migueldotl-portfolio).
+
+## What's in here
+
+**[Showcase](/?path=/docs/showcase-sections-hero--docs)** — the live page sections. Hero, NavBar, Projects, Skills, ContactMe, Footer. Useful for visual regression and seeing each section in isolation.
+
+**[Components](/?path=/docs/components-primitives-button--docs)** — the reusable React building blocks split into `Composites` (multi-part, e.g. `<MomentumTabs>`, `<ContactForm>`) and `Primitives` (single-purpose, e.g. `<Button>`, `<NavLink>`).
+
+**[Foundations](/?path=/docs/foundations-overview--docs)** — pure CSS utility classes you drop on any element. No JSX, no React. See the [overview](/?path=/docs/foundations-overview--docs) for the foundations-vs-components distinction.
+
+**[Design Iterations](/?path=/docs/design-iterations-projecttabs--pill-fill-sliding)** — design exploration. Iterations of components that may or may not have shipped. Useful for "why does it look the way it does" history.
+
+## Where to start
+
+- **First time?** Skim a section in Showcase, then check a primitive (`Components/Primitives/Button`).
+- **Looking for a reusable hover/animation?** [Foundations overview](/?path=/docs/foundations-overview--docs).
+- **Curious about a design choice?** Browse Design Iterations.
+
+## Conventions
+
+- Component stories live next to the component: `Foo.tsx` + `Foo.stories.tsx`.
+- Foundations live in [`src/effects/`](https://github.com/MiguelDotL/migueldotl-portfolio/tree/main/src/effects) — one CSS file + one story per effect, with a barrel `index.css` imported globally.
+- Component types are exported alongside components (e.g. `MomentumTabsProps`).
+- All stories pass axe (with two narrow disables: Hero color-contrast and `.sb-mock__brand` — see those stories' notes for why).

--- a/src/assets/styles/Footer.css
+++ b/src/assets/styles/Footer.css
@@ -18,6 +18,12 @@
     }
 }
 
+@media (max-width: 767px) {
+    .built-with {
+        border-radius: 29px;
+    }
+}
+
 .built-with h3 {
     font-weight: 700;
     letter-spacing: 0.5px;
@@ -366,7 +372,9 @@
 
 /* Iframe renders at a wider virtual viewport (111%) and scales to fit
    (0.9). Slight zoom-out gives the SB story a touch more horizontal room
-   while staying close to natural size. */
+   while staying close to natural size. On mobile the card is too narrow
+   for native-scale story content, so zoom out further (200% viewport,
+   0.5 scale) to fit the whole iteration. */
 .sb-mock__iframe {
     width: 111.11%;
     height: 111.11%;
@@ -376,6 +384,14 @@
     display: block;
     pointer-events: none;
     background: #fff;
+}
+
+@media (max-width: 768px) {
+    .sb-mock__iframe {
+        width: 200%;
+        height: 200%;
+        transform: scale(0.5);
+    }
 }
 
 .sb-frame__overlay {

--- a/src/assets/styles/Hero.css
+++ b/src/assets/styles/Hero.css
@@ -107,10 +107,16 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    text-align: center;
+}
+
+.hero .image-col picture {
+    display: block;
+    margin: 0 auto;
 }
 
 .hero img.floating-image {
-    margin: 4em 0 -4em;
+    margin: 4em auto -4em;
     height: auto;
     width: 80%;
     transition: all 0.3s ease-in-out;

--- a/src/assets/styles/MomentumTabs.css
+++ b/src/assets/styles/MomentumTabs.css
@@ -7,6 +7,17 @@
     margin: 3.5em 0;
 }
 
+@media (max-width: 768px) {
+    .momentum-tabs {
+        margin: 3.5em 1em;
+        gap: 0.5em;
+    }
+    .momentum-tab {
+        padding: 0.8em 0.6em;
+        font-size: 14px;
+    }
+}
+
 .momentum-tab {
     position: relative;
     background: transparent;

--- a/src/assets/styles/NavBar.css
+++ b/src/assets/styles/NavBar.css
@@ -9,7 +9,7 @@ nav.navbar {
 }
 
 nav.navbar.has-bg {
-  background-color: var(--dark-grey);
+  background-color: var(--darker-grey);
 }
 
 nav.navbar .container {
@@ -18,7 +18,7 @@ nav.navbar .container {
 
 nav.navbar.has-scrolled {
   padding: .5em 0;
-  background-color: var(--dark-grey);
+  background-color: var(--darker-grey);
   box-shadow: 0 1px 10px rgb(0 0 0 / 50%);
 }
 

--- a/src/assets/styles/Skills.css
+++ b/src/assets/styles/Skills.css
@@ -249,3 +249,8 @@
         font-size: 10em;
     }
 }
+@media (max-width: 767px) {
+    .skills-content {
+        border-radius: 29px;
+    }
+}

--- a/src/effects/FadeScaleIn.mdx
+++ b/src/effects/FadeScaleIn.mdx
@@ -1,0 +1,64 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './FadeScaleIn.stories';
+
+<Meta of={Stories} />
+
+# FadeScaleIn
+
+Modal/lightbox/dialog open transition. Element fades in while scaling up from a slightly smaller size. Run-once via `animation`, not a state toggle.
+
+Originally on the FeaturedImageSlider lightbox overlay.
+
+## When to use
+
+- Modals, dialogs, lightboxes, popovers — any UI that snaps in on open.
+- One-shot transitions where you don't need bidirectional state. (For state-driven open/close, reach for `.fan-out` or roll your own transition.)
+
+## How it works
+
+Single `@keyframes` animation:
+
+- `from`: `opacity: 0; transform: scale(var(--fade-scale-from, 0.96))`
+- `to`: `opacity: 1; transform: scale(1)`
+
+Plays once on mount with `animation`. Element stays at its end state once finished — no infinite loop, no reverse on exit.
+
+## API
+
+| Variable | Default | Effect |
+|---|---|---|
+| `--fade-scale-from` | `0.96` | Starting scale (1 = no scale, just fade) |
+| `--fade-scale-duration` | `180ms` | Animation duration |
+
+## Usage
+
+```jsx
+{isOpen && (
+  <div className="fade-scale-in modal">
+    <h2>Modal content</h2>
+  </div>
+)}
+
+{/* Slower, more dramatic scale */}
+<div
+  className="fade-scale-in"
+  style={{
+    '--fade-scale-from': '0.8',
+    '--fade-scale-duration': '500ms'
+  }}
+>
+  Slow open
+</div>
+```
+
+The `Replay` button in the stories re-mounts the element by changing its key — that's how you'd verify the animation in dev too.
+
+## Examples
+
+<Canvas of={Stories.Default} />
+<Canvas of={Stories.SlowAndStrong} />
+
+## Caveats
+
+- **Mount/unmount only.** Animation runs once when the element mounts. If you want a corresponding fade-out on unmount, you need React Transition Group, Framer Motion, or a CSS transition driven by an `.is-leaving` class — `.fade-scale-in` won't do it.
+- **Initial render gotcha.** If the element is in the DOM at page load, the animation runs immediately and may compete with LCP. For dialogs that open on user action, this is fine. For above-the-fold content, prefer a class-toggle transition.

--- a/src/effects/FadeScaleIn.stories.tsx
+++ b/src/effects/FadeScaleIn.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import './fade-scale-in.css';
+
+/**
+ * `.fade-scale-in` — modal/lightbox open transition. Originally on
+ * FeaturedImageSlider's lightbox overlay. Tune `--fade-scale-from`
+ * and `--fade-scale-duration`.
+ *
+ * Stories include a "Replay" toggle so you can see the animation
+ * fire repeatedly without reloading the canvas.
+ */
+const Modal = ({ style }: { style?: React.CSSProperties }) => (
+    <div
+        className="fade-scale-in"
+        style={{
+            background: '#fff',
+            color: '#222',
+            padding: '2em 3em',
+            borderRadius: 12,
+            boxShadow: '0 20px 60px rgba(0,0,0,0.5)',
+            maxWidth: 360,
+            ...style
+        }}
+    >
+        <h3 style={{ marginTop: 0 }}>Modal</h3>
+        <p>Drops in with `.fade-scale-in`.</p>
+    </div>
+);
+
+const Stage = ({ children, onReplay }: { children?: React.ReactNode; onReplay: () => void }) => (
+    <div
+        style={{
+            background:
+                'linear-gradient(131deg, #1d1d3f 0%, #4A2FBD 100%)',
+            padding: '4em 2em',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            minHeight: '60vh',
+            position: 'relative'
+        }}
+    >
+        <button
+            onClick={onReplay}
+            style={{
+                position: 'absolute',
+                top: 16,
+                right: 16,
+                padding: '8px 16px',
+                borderRadius: 8,
+                border: '1px solid rgba(255,255,255,0.3)',
+                background: 'rgba(0,0,0,0.4)',
+                color: '#fff',
+                cursor: 'pointer'
+            }}
+        >
+            ↻ Replay
+        </button>
+        {children}
+    </div>
+);
+
+const Replay = ({ children }: { children: (key: number) => React.ReactNode }) => {
+    const [key, setKey] = useState(0);
+    return <Stage onReplay={() => setKey((k) => k + 1)}>{children(key)}</Stage>;
+};
+
+const meta: Meta = {
+    title: 'Foundations/Motion/FadeScaleIn',
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    'Modal open animation — `.fade-scale-in`. Tune `--fade-scale-from` and `--fade-scale-duration`.'
+            }
+        }
+    }
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Default: Story = {
+    render: () => <Replay>{(key) => <Modal key={key} />}</Replay>
+};
+
+export const SlowAndStrong: Story = {
+    render: () => (
+        <Replay>
+            {(key) => (
+                <Modal
+                    key={key}
+                    style={
+                        {
+                            ['--fade-scale-from' as string]: '0.8',
+                            ['--fade-scale-duration' as string]: '500ms'
+                        } as React.CSSProperties
+                    }
+                />
+            )}
+        </Replay>
+    )
+};

--- a/src/effects/FanOut.mdx
+++ b/src/effects/FanOut.mdx
@@ -1,0 +1,50 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './FanOut.stories';
+
+<Meta of={Stories} />
+
+# FanOut
+
+Items go from a stacked cluster (each child overlapping its left neighbor) to a spread row when the container — or any ancestor — gains `.is-open`. Originally a happy accident in the navbar mobile-menu social icons; captured here so the effect is reusable on any horizontal cluster.
+
+## When to use
+
+- A row of items (icons, badges, chips) that should reveal-and-spread when a section opens.
+- Anywhere you want a small "fan out from the corner" reveal that's CSS-only — no JS animation library.
+
+## How it works
+
+Each direct child of `.fan-out` has `margin-right: var(--fan-out-stacked, -2.6em)` while closed (negative pulls each onto its left neighbor) and `var(--fan-out-spread, 1.5em)` when open. Opacity transitions in lockstep, sequenced via `transition-delay` so the two phases land one after the other:
+
+- **Enter** (`.is-open` added): opacity 0 → 1 first, then margin spreads.
+- **Exit** (`.is-open` removed): margin re-stacks first, then opacity fades.
+
+The last child stays at `margin-right: 0` so the cluster grows from the right.
+
+## API
+
+| Variable | Default | Effect |
+|---|---|---|
+| `--fan-out-stacked` | `-2.6em` | Closed-state right margin per child |
+| `--fan-out-spread` | `1.5em` | Open-state right margin per child |
+| `--fan-out-stacked-opacity` | `0` | Closed-state opacity per child |
+| `--fan-out-spread-opacity` | `1` | Open-state opacity per child |
+| `--fan-out-step-duration` | `0.3s` | Duration of each phase (total per direction = 2×) |
+
+## Usage
+
+```jsx
+<div className={`fan-out ${menuOpen ? 'is-open' : ''}`}>
+  <Icon a /> <Icon b /> <Icon c />
+</div>
+```
+
+## Examples
+
+<Canvas of={Stories.Default} />
+<Canvas of={Stories.WiderSpread} />
+<Canvas of={Stories.Subtle} />
+
+## Caveat — specificity
+
+`.fan-out > *` targets direct children with one class selector. If those children inherit a `margin-right` from a more specific selector (e.g. `.social-icons a.social-icon` — two classes plus an element), the foundation silently loses. Either rename the wrapper, drop the conflicting class on the children, or apply `.fan-out` directly to the wrapper that owns those rules.

--- a/src/effects/FanOut.stories.tsx
+++ b/src/effects/FanOut.stories.tsx
@@ -1,0 +1,116 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useEffect, useState } from 'react';
+import { NAV_SOCIALS } from '../data/socials';
+import './fan-out.css';
+
+/**
+ * Documents the `.fan-out` reusable class — extracted from the navbar
+ * mobile-menu happy accident where social icons spring from a stacked
+ * cluster to a spread row when the menu opens.
+ *
+ * The mechanic: each direct child of `.fan-out` has
+ * `margin-right: var(--fan-out-stacked, -2.6em)` while closed, then flips
+ * to `var(--fan-out-spread, 1.5em)` under `.is-open`. The 0.3s margin
+ * transition handles the animation. The last child stays at 0 so the
+ * cluster grows from the right.
+ *
+ * **Important:** `.fan-out` targets direct children. Don't combine it
+ * with a wrapper class whose own rules set `margin-right` on the same
+ * children (e.g. the project's `.social-icons` does this). Either rename
+ * the wrapper or use `.fan-out` on a plain container, as in this story.
+ */
+const Circle = ({ icon, label }: { icon: string; label: string }) => (
+    <span
+        aria-label={label}
+        style={{
+            width: 42,
+            height: 42,
+            borderRadius: '50%',
+            background: 'rgba(217, 217, 217, 0.1)',
+            border: '1px solid rgba(255, 255, 255, 0.5)',
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center'
+        }}
+    >
+        <img src={icon} alt="" width={18} height={18} />
+    </span>
+);
+
+const FanOut = ({ style }: { style?: React.CSSProperties }) => {
+    const [open, setOpen] = useState(false);
+
+    useEffect(() => {
+        const id = window.setInterval(() => setOpen((v) => !v), 2200);
+        return () => window.clearInterval(id);
+    }, []);
+
+    return (
+        <div
+            style={{
+                background: '#1f1f1f',
+                padding: '3em 2em',
+                display: 'flex',
+                justifyContent: 'center'
+            }}
+        >
+            <div
+                className={`fan-out ${open ? 'is-open' : ''}`}
+                style={{ display: 'flex', ...style }}
+            >
+                {NAV_SOCIALS.map((s) => (
+                    <Circle key={s.className} icon={s.icon} label={s.label} />
+                ))}
+            </div>
+        </div>
+    );
+};
+
+const meta: Meta<typeof FanOut> = {
+    title: 'Foundations/Motion/FanOut',
+    component: FanOut,
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    'Reusable cluster-to-spread animation. Apply `.fan-out` to a horizontal container and toggle `.is-open` (on the same element or any ancestor) to animate. Customize via `--fan-out-stacked` and `--fan-out-spread` CSS variables. Origin: navbar mobile-menu happy accident, see NavBar.css `nav.has-bg .social-icons a.social-icon`.'
+            }
+        }
+    }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FanOut>;
+
+/** Default: -2.6em stacked → 1.5em spread, 0.3s ease-in-out. Auto-loops. */
+export const Default: Story = {};
+
+/** Tighter cluster, wider spread. */
+export const WiderSpread: Story = {
+    render: () => (
+        <FanOut
+            style={
+                {
+                    ['--fan-out-stacked' as string]: '-2em',
+                    ['--fan-out-spread' as string]: '3em'
+                } as React.CSSProperties
+            }
+        />
+    )
+};
+
+/** Subtle: barely-overlapping cluster, modest spread. */
+export const Subtle: Story = {
+    render: () => (
+        <FanOut
+            style={
+                {
+                    ['--fan-out-stacked' as string]: '-1em',
+                    ['--fan-out-spread' as string]: '0.8em'
+                } as React.CSSProperties
+            }
+        />
+    )
+};

--- a/src/effects/Float.mdx
+++ b/src/effects/Float.mdx
@@ -1,0 +1,51 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './Float.stories';
+
+<Meta of={Stories} />
+
+# Float
+
+Gentle vertical bob. Originally the Hero bitmoji's signature animation (`@keyframes updown` + 6s linear infinite). Generic enough for any decorative floating element.
+
+## When to use
+
+- Decorative imagery (mascots, illustrations, icon clusters) that should feel "alive" without distracting from real content.
+- Hero / above-the-fold focal points where a tiny bit of motion catches the eye.
+
+## How it works
+
+Infinite `transform: translateY` keyframe oscillating between `-var(--float-distance)` and `+var(--float-distance)`. Eased in/out so the reversal at each peak feels organic. Symmetric — no jump on mount.
+
+## API
+
+| Variable | Default | Effect |
+|---|---|---|
+| `--float-distance` | `1em` | Peak displacement up/down |
+| `--float-duration` | `6s` | Full cycle duration |
+
+## Usage
+
+```jsx
+<img className="float" src={mascot} alt="" />
+
+{/* Subtler, slower */}
+<div
+  className="float"
+  style={{
+    '--float-distance': '0.4em',
+    '--float-duration': '10s'
+  }}
+>
+  Slow drift
+</div>
+```
+
+## Examples
+
+<Canvas of={Stories.Default} />
+<Canvas of={Stories.Variants} />
+
+## Caveats
+
+- **Respect `prefers-reduced-motion`.** This foundation runs unconditionally. If you ship it on a high-traffic surface, wrap it in a media query that disables the animation for users who've requested reduced motion.
+- **Layout impact.** `transform: translateY` doesn't reflow neighbors, but if the element has margins/padding tuned visually for its bobbing, surrounding elements may feel uneven.

--- a/src/effects/Float.stories.tsx
+++ b/src/effects/Float.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import './float.css';
+
+/**
+ * Documents the `.float` reusable class — gentle vertical bob. Originally
+ * the Hero bitmoji's signature animation (`@keyframes updown` + `animation:
+ * updown 6s linear infinite`). Generic enough for any decorative floating
+ * element.
+ *
+ * Customize via CSS variables:
+ *   --float-distance  (default 1em) — peak displacement
+ *   --float-duration  (default 6s)  — full cycle
+ */
+const Orb = ({ style }: { style?: React.CSSProperties }) => (
+    <div
+        className="float"
+        style={{
+            width: 96,
+            height: 96,
+            borderRadius: '50%',
+            background:
+                'radial-gradient(circle at 30% 30%, #fff 0%, #AA367C 40%, #4A2FBD 100%)',
+            boxShadow: '0 12px 40px rgba(74, 47, 189, 0.5)',
+            ...style
+        }}
+    />
+);
+
+const Stage = ({ children }: { children: React.ReactNode }) => (
+    <div
+        style={{
+            background: '#1f1f1f',
+            padding: '6em 2em',
+            display: 'flex',
+            gap: '4em',
+            justifyContent: 'center',
+            alignItems: 'center',
+            minHeight: '60vh'
+        }}
+    >
+        {children}
+    </div>
+);
+
+const meta: Meta = {
+    title: 'Foundations/Motion/Float',
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    'Vertical bob — `.float`. Tune `--float-distance` and `--float-duration`.'
+            }
+        }
+    }
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Default: Story = {
+    render: () => (
+        <Stage>
+            <Orb />
+        </Stage>
+    )
+};
+
+export const Variants: Story = {
+    render: () => (
+        <Stage>
+            <Orb
+                style={
+                    {
+                        ['--float-distance' as string]: '0.4em',
+                        ['--float-duration' as string]: '3s'
+                    } as React.CSSProperties
+                }
+            />
+            <Orb />
+            <Orb
+                style={
+                    {
+                        ['--float-distance' as string]: '2em',
+                        ['--float-duration' as string]: '10s'
+                    } as React.CSSProperties
+                }
+            />
+        </Stage>
+    )
+};

--- a/src/effects/Foundations.mdx
+++ b/src/effects/Foundations.mdx
@@ -1,0 +1,67 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Foundations/Overview" />
+
+# Foundations
+
+Pure CSS utility classes. No JSX, no React. You drop them on whatever markup you already have.
+
+## Foundations vs Components — the bright line
+
+| | Foundation | Component |
+|---|---|---|
+| What it is | A CSS class | A React component |
+| How you use it | `<div class="lift">` | `import Button; <Button />` |
+| Owns markup? | No — decorates yours | Yes — provides JSX |
+| Owns state? | Only what `:hover` / `.is-open` toggles give | Can have hooks, refs, effects |
+| Composes by | Combining classes (`<div class="lift frosted">`) | Nesting JSX |
+| Could a non-React project use it? | Yes | No |
+
+If you can drop the class on existing markup without restructuring, it's a Foundation.
+If you have to import and render it as JSX, it's a Component.
+
+## Sub-categories
+
+Effects fall into three discoverable buckets:
+
+- **Motion** — animations or state-driven transitions. Self-running keyframes (`Float`, `Shimmer`) or class-toggle transitions (`FanOut`, `FadeScaleIn`).
+- **Hover** — driven by `:hover`. `Lift`, `GradientPair`.
+- **Material** — static visual treatments. `Frosted`.
+
+## CSS-variable conventions
+
+Every foundation exposes its tunables as CSS custom properties with sensible defaults:
+
+```css
+.lift:hover {
+    box-shadow: var(--lift-shadow, 0 8px 18px rgba(20, 20, 40, 0.25));
+}
+```
+
+This lets you keep one class but customize per-context without writing new CSS:
+
+```jsx
+<div
+    className="lift"
+    style={{ '--lift-shadow': '0 12px 32px rgba(170, 54, 124, 0.45)' }}
+>
+    pink-glow lift
+</div>
+```
+
+## How to add a new foundation
+
+1. Drop a new CSS file in `src/effects/`, e.g. `glow.css`. Top of the file gets a JSDoc-style comment block: what it does, where it came from, what CSS variables it exposes.
+2. Add `@import './glow.css';` to `src/effects/index.css` (the barrel imported once globally in `src/index.tsx`).
+3. Add a matching `Glow.stories.tsx` in the same folder. Title prefix is one of `Foundations/Motion/...`, `Foundations/Hover/...`, or `Foundations/Material/...` depending on what kind of effect it is.
+4. Story imports its own per-effect CSS file directly (`import './glow.css'`), not the barrel — keeps stories isolated.
+
+## Origin
+
+Most foundations were extracted from patterns that emerged organically across the live components — duplicated hover lifts, repeated `backdrop-filter` recipes, the navbar mobile-menu happy accident. Capturing them here is documentation as much as reuse: future refactors won't lose the pattern silently.
+
+The live components keep their original CSS for now. Adoption of the foundations is opportunistic — drop them on new code; refactor the old gradually if it pays for itself.
+
+## Specificity gotcha
+
+Class selectors targeting children (`.fan-out > *`) can lose to component-internal rules with stacked selectors (`.social-icons a.social-icon`). If a foundation isn't taking effect, check the children's existing CSS — combining a foundation with a wrapper class whose own rules touch the same property on the same children will silently override the foundation. The `FanOut` story has a worked example.

--- a/src/effects/Frosted.mdx
+++ b/src/effects/Frosted.mdx
@@ -1,0 +1,52 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './Frosted.stories';
+
+<Meta of={Stories} />
+
+# Frosted
+
+The portfolio's signature glass material — translucent white tint over a backdrop blur and saturate. Used 8+ times across MomentumTabs, FeaturedImageSlider dots/arrows, and project cards.
+
+## When to use
+
+- Floating UI surfaces (dropdowns, popovers, dot indicators) over rich/photographic backgrounds.
+- Anywhere you'd reach for `backdrop-filter: blur(...)` — this codifies the project's specific recipe.
+
+## API
+
+| Variable | Default | Effect |
+|---|---|---|
+| `--frosted-bg` | `rgba(255, 255, 255, 0.05)` | Tint color and opacity |
+| `--frosted-blur` | `10px` | Blur radius |
+| `--frosted-saturate` | `1.3` | Saturation multiplier |
+
+## Usage
+
+```jsx
+<div className="frosted">
+  Glass surface
+</div>
+
+{/* Stronger blur, warmer tint */}
+<div
+  className="frosted"
+  style={{
+    '--frosted-blur': '20px',
+    '--frosted-bg': 'rgba(255, 200, 140, 0.08)'
+  }}
+>
+  Stronger glass
+</div>
+```
+
+## Examples
+
+<Canvas of={Stories.Default} />
+<Canvas of={Stories.TuneBlur} />
+<Canvas of={Stories.TuneTint} />
+
+## Caveats
+
+- **Blur needs detail behind it.** Backdrop-filter is most visible against high-frequency content (text, images). On a flat gradient the effect is barely perceptible — the stories deliberately layer text behind the tile so the blur has something to chew on.
+- **Browser support.** `backdrop-filter` works everywhere modern but may need `-webkit-backdrop-filter` for older Safari (the foundation includes both prefixes). When unsupported, the element falls back to its `--frosted-bg` tint with no blur.
+- **Opaque backgrounds break it.** The element's own `background-color` must be non-opaque, and there must be something visible *behind* it. A solid parent or `background: white` on the element itself defeats the filter.

--- a/src/effects/Frosted.stories.tsx
+++ b/src/effects/Frosted.stories.tsx
@@ -1,0 +1,166 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import './frosted.css';
+
+/**
+ * Documents the `.frosted` reusable class — the portfolio's signature
+ * glass material. Translucent white tint over a backdrop blur+saturate.
+ * Currently duplicated across MomentumTabs, FeaturedImageSlider dots/arrows,
+ * and project cards.
+ *
+ * Tune via CSS variables on the element:
+ *   --frosted-bg       (rgba tint)
+ *   --frosted-blur     (blur radius)
+ *   --frosted-saturate (saturation multiplier)
+ *
+ * Stories render against a text-wall + diagonal-stripe backdrop. Blur is
+ * most visible against high-frequency content; a flat gradient blurs into
+ * itself and you can barely tell the effect is there.
+ */
+const TEXT_WALL = Array.from(
+    { length: 200 },
+    () => 'frosted • backdrop-filter • blur • saturate '
+).join('');
+
+const Stage = ({ children }: { children: React.ReactNode }) => (
+    <div
+        style={{
+            position: 'relative',
+            background:
+                'linear-gradient(131deg, #AA367C 0%, #4A2FBD 50%, #1d1d3f 100%)',
+            padding: '4em 2em',
+            display: 'flex',
+            gap: '2em',
+            justifyContent: 'center',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            minHeight: '60vh',
+            overflow: 'hidden'
+        }}
+    >
+        <div
+            aria-hidden
+            style={{
+                position: 'absolute',
+                inset: 0,
+                padding: '1em',
+                fontFamily: 'monospace',
+                fontSize: 10,
+                lineHeight: 1.4,
+                color: 'rgba(255,255,255,0.35)',
+                wordBreak: 'break-all',
+                userSelect: 'none',
+                pointerEvents: 'none'
+            }}
+        >
+            {TEXT_WALL}
+        </div>
+        <div
+            style={{
+                position: 'relative',
+                display: 'flex',
+                gap: '2em',
+                flexWrap: 'wrap',
+                justifyContent: 'center'
+            }}
+        >
+            {children}
+        </div>
+    </div>
+);
+
+const Tile = ({
+    label,
+    style
+}: {
+    label: string;
+    style?: React.CSSProperties;
+}) => (
+    <div
+        className="frosted"
+        style={{
+            color: '#fff',
+            padding: '2em 3em',
+            borderRadius: 12,
+            border: '1px solid rgba(255,255,255,0.15)',
+            fontWeight: 600,
+            ...style
+        }}
+    >
+        {label}
+    </div>
+);
+
+const meta: Meta = {
+    title: 'Foundations/Material/Frosted',
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    'Glass material — `.frosted`. Tune `--frosted-bg`, `--frosted-blur`, `--frosted-saturate`.'
+            }
+        }
+    }
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Default: Story = {
+    render: () => (
+        <Stage>
+            <Tile label="default (10px blur, 1.3 saturate)" />
+        </Stage>
+    )
+};
+
+export const TuneBlur: Story = {
+    render: () => (
+        <Stage>
+            <Tile
+                label="4px blur"
+                style={{ ['--frosted-blur' as string]: '4px' } as React.CSSProperties}
+            />
+            <Tile
+                label="10px blur"
+                style={{ ['--frosted-blur' as string]: '10px' } as React.CSSProperties}
+            />
+            <Tile
+                label="20px blur"
+                style={{ ['--frosted-blur' as string]: '20px' } as React.CSSProperties}
+            />
+        </Stage>
+    )
+};
+
+export const TuneTint: Story = {
+    render: () => (
+        <Stage>
+            <Tile
+                label="cool tint"
+                style={
+                    {
+                        ['--frosted-bg' as string]: 'rgba(140, 180, 255, 0.08)'
+                    } as React.CSSProperties
+                }
+            />
+            <Tile
+                label="warm tint"
+                style={
+                    {
+                        ['--frosted-bg' as string]: 'rgba(255, 200, 140, 0.08)'
+                    } as React.CSSProperties
+                }
+            />
+            <Tile
+                label="dark tint"
+                style={
+                    {
+                        ['--frosted-bg' as string]: 'rgba(0, 0, 0, 0.25)'
+                    } as React.CSSProperties
+                }
+            />
+        </Stage>
+    )
+};

--- a/src/effects/GradientPair.mdx
+++ b/src/effects/GradientPair.mdx
@@ -1,0 +1,64 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './GradientPair.stories';
+
+<Meta of={Stories} />
+
+# GradientPair
+
+Two adjacent buttons that share a continuous gradient. Hover the secondary: it fills L→R with the gradient, and the primary's gradient angle rotates 180° so the visual gradient appears to flow continuously across both buttons.
+
+Origin: PreFooter "The Repo" + "Storybook" CTAs.
+
+## When to use
+
+- Paired actions where one is a primary CTA and the other is a secondary (e.g. "View" + "Learn more").
+- When you want the pair to feel coordinated — a hover on one is reflected in the other.
+
+## How it works
+
+Two cooperating mechanisms:
+
+1. **Secondary fill**: a `::before` pseudo-element on `.gradient-pair__secondary` starts at `width: 0` and animates to `100%` on hover, painted with the same gradient as the primary.
+2. **Primary rotation**: when the secondary is hovered, `:has(.gradient-pair__secondary:hover)` on the parent flips a custom property `--gp-angle` from the base angle (131°) to the flipped angle (311°). The primary's `linear-gradient(var(--gp-angle), ...)` re-renders with the new angle. To make this animate (rather than snap), `--gp-angle` is registered with `@property` so the browser knows it's an `<angle>` and can interpolate between values.
+
+## API
+
+| Variable | Default | Effect |
+|---|---|---|
+| `--gp-color-1` | `#aa367c` | Gradient stop 1 |
+| `--gp-color-2` | `#4a2fbd` | Gradient stop 2 |
+| `--gp-angle-base` | `131deg` | Primary's resting angle |
+| `--gp-angle-flipped` | `311deg` | Primary's hovered-state angle (180° from base) |
+
+## Usage
+
+```jsx
+<div className="gradient-pair">
+  <a className="gradient-pair__primary" href="...">Primary</a>
+  <a className="gradient-pair__secondary" href="...">Secondary</a>
+</div>
+
+{/* Custom gradient colors */}
+<div
+  className="gradient-pair"
+  style={{
+    '--gp-color-1': '#0d9488',
+    '--gp-color-2': '#ea580c'
+  }}
+>
+  ...
+</div>
+```
+
+## Examples
+
+<Canvas of={Stories.Default} />
+<Canvas of={Stories.TealOrange} />
+<Canvas of={Stories.FlatRectangle} />
+
+## Caveats
+
+- **Browser support — `@property`.** Safari 16.4+, Chrome 85+, Firefox 128+. Without it, the gradient angle snaps instead of animating; the rest still works.
+- **Browser support — `:has()`.** Safari 15.4+, Chrome 105+, Firefox 121+. Without it, the cross-button coordination doesn't fire — the secondary still fills on its own hover, but the primary stays at its base angle.
+- **Two-button assumption.** The `:has()` selector is hardcoded for one primary + one secondary. Adding a third button or a different child structure breaks the coordination. For richer compositions, treat this as a starting point and fork.
+- **The flipped angle should be 180° from base.** That's what makes the "continuous gradient" illusion work — the pink-end of one button visually meets the pink-start of the other. Picking other angle deltas creates a different visual that may or may not look intentional.

--- a/src/effects/GradientPair.stories.tsx
+++ b/src/effects/GradientPair.stories.tsx
@@ -1,0 +1,162 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import './gradient-pair.css';
+
+/**
+ * `.gradient-pair` — two adjacent buttons that share a continuous gradient.
+ *
+ * Hover the secondary button: it fills L→R with the gradient, and the
+ * primary's gradient angle rotates 180° so the visual gradient appears
+ * to flow continuously across both buttons (purple → pink → pink → purple).
+ *
+ * Origin: PreFooter "The Repo" + "Storybook" CTAs.
+ *
+ * Browser support: requires @property and :has() (modern browsers only).
+ */
+const Pair = ({
+    primaryLabel = 'Primary',
+    secondaryLabel = 'Secondary',
+    style
+}: {
+    primaryLabel?: string;
+    secondaryLabel?: string;
+    style?: React.CSSProperties;
+}) => (
+    <div
+        className="gradient-pair"
+        style={{
+            display: 'inline-flex',
+            gap: '0.6em',
+            ...style
+        }}
+    >
+        <a
+            className="gradient-pair__primary"
+            href="#"
+            onClick={(e) => e.preventDefault()}
+            style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                padding: '0.7em 1.4em',
+                borderRadius: 999,
+                fontWeight: 600,
+                textDecoration: 'none',
+                lineHeight: 1.2
+            }}
+        >
+            {primaryLabel}
+        </a>
+        <a
+            className="gradient-pair__secondary"
+            href="#"
+            onClick={(e) => e.preventDefault()}
+            style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                padding: 'calc(0.7em - 2px) calc(1.4em - 2px)',
+                borderRadius: 999,
+                fontWeight: 600,
+                textDecoration: 'none',
+                lineHeight: 1.2
+            }}
+        >
+            {secondaryLabel}
+        </a>
+    </div>
+);
+
+const Stage = ({ children }: { children: React.ReactNode }) => (
+    <div
+        style={{
+            background: '#fff',
+            padding: '6em 3em',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            minHeight: '60vh'
+        }}
+    >
+        {children}
+    </div>
+);
+
+const meta: Meta = {
+    title: 'Foundations/Hover/GradientPair',
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    'Coordinated hover on a button pair. Hover the secondary to see the primary rotate its gradient 180° while the secondary fills.'
+            }
+        }
+    }
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Default: Story = {
+    render: () => (
+        <Stage>
+            <Pair primaryLabel="The Repo" secondaryLabel="Storybook" />
+        </Stage>
+    )
+};
+
+export const TealOrange: Story = {
+    render: () => (
+        <Stage>
+            <Pair
+                primaryLabel="Primary"
+                secondaryLabel="Secondary"
+                style={
+                    {
+                        ['--gp-color-1' as string]: '#0d9488',
+                        ['--gp-color-2' as string]: '#ea580c'
+                    } as React.CSSProperties
+                }
+            />
+        </Stage>
+    )
+};
+
+export const FlatRectangle: Story = {
+    render: () => (
+        <Stage>
+            <div
+                className="gradient-pair"
+                style={{ display: 'inline-flex' }}
+            >
+                <a
+                    className="gradient-pair__primary"
+                    href="#"
+                    onClick={(e) => e.preventDefault()}
+                    style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        padding: '0.9em 2em',
+                        fontWeight: 600,
+                        textDecoration: 'none'
+                    }}
+                >
+                    Primary
+                </a>
+                <a
+                    className="gradient-pair__secondary"
+                    href="#"
+                    onClick={(e) => e.preventDefault()}
+                    style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        padding: 'calc(0.9em - 2px) calc(2em - 2px)',
+                        fontWeight: 600,
+                        textDecoration: 'none'
+                    }}
+                >
+                    Secondary
+                </a>
+            </div>
+        </Stage>
+    )
+};

--- a/src/effects/Lift.mdx
+++ b/src/effects/Lift.mdx
@@ -1,0 +1,55 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './Lift.stories';
+
+<Meta of={Stories} />
+
+# Lift
+
+Translate-up + shadow-boost on hover. The portfolio's standard "this surface is interactive" feedback. Mirrors what's currently duplicated on `.cta-btn`, `.sb-frame`, and `.featured-project-card`.
+
+## When to use
+
+- Buttons, cards, and other clickable surfaces that should respond to pointer hover.
+- Drop-in replacement for hand-rolled hover translates inside individual component CSS.
+
+## Variants
+
+Three sizes, picked by composition with a modifier class:
+
+| Class | translateY | Shadow |
+|---|---|---|
+| `.lift` | `-2px` | small drop |
+| `.lift.lift--md` | `-4px` | medium drop |
+| `.lift.lift--lg` | `-6px` | large drop |
+
+All variants animate over 0.2s ease.
+
+## API
+
+| Variable | Default | Effect |
+|---|---|---|
+| `--lift-shadow` | size-dependent neutral dark drop | Override the box-shadow per instance |
+
+## Usage
+
+```jsx
+<button className="lift">Default lift</button>
+<a className="lift lift--md">Medium lift</a>
+
+{/* Pink-glow variant via CSS var */}
+<div
+  className="lift lift--md"
+  style={{ '--lift-shadow': '0 12px 32px rgba(170, 54, 124, 0.45)' }}
+>
+  Custom shadow
+</div>
+```
+
+## Examples
+
+<Canvas of={Stories.AllSizes} />
+<Canvas of={Stories.CustomShadow} />
+
+## Caveat — transform stacking
+
+`.lift:hover` sets `transform: translateY(...)`. If the element already has another transform (rotate, scale), they collide. Either drop the existing transform or write a custom hover that composes both into one transform shorthand.

--- a/src/effects/Lift.stories.tsx
+++ b/src/effects/Lift.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import './lift.css';
+
+/**
+ * Documents the `.lift` reusable class — the portfolio's standard
+ * "interactive surface" hover feedback. Mirrors what's currently
+ * duplicated on `.cta-btn`, `.sb-frame`, and `.featured-project-card`.
+ *
+ * Three sizes: default (-2px), `.lift--md` (-4px), `.lift--lg` (-6px).
+ * Customize the shadow per-instance via the `--lift-shadow` CSS var.
+ *
+ * Hover the cards to see the lift.
+ */
+const Sample = ({
+    label,
+    extraClass = ''
+}: {
+    label: string;
+    extraClass?: string;
+}) => (
+    <div
+        className={`lift ${extraClass}`.trim()}
+        style={{
+            background: '#2a2a2a',
+            color: '#fff',
+            padding: '2em 3em',
+            borderRadius: 12,
+            fontWeight: 600,
+            cursor: 'pointer',
+            userSelect: 'none'
+        }}
+    >
+        {label}
+    </div>
+);
+
+const Stage = ({ children }: { children: React.ReactNode }) => (
+    <div
+        style={{
+            background: '#1f1f1f',
+            padding: '4em 2em',
+            display: 'flex',
+            gap: '2em',
+            justifyContent: 'center',
+            flexWrap: 'wrap'
+        }}
+    >
+        {children}
+    </div>
+);
+
+const meta: Meta = {
+    title: 'Foundations/Hover/Lift',
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    'Hover lift utility — `.lift`, `.lift--md`, `.lift--lg`. Translates -2/-4/-6px and boosts box-shadow. 0.2s ease. Override shadow with `--lift-shadow`.'
+            }
+        }
+    }
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const AllSizes: Story = {
+    render: () => (
+        <Stage>
+            <Sample label="default (-2px)" />
+            <Sample label="lift--md (-4px)" extraClass="lift--md" />
+            <Sample label="lift--lg (-6px)" extraClass="lift--lg" />
+        </Stage>
+    )
+};
+
+export const CustomShadow: Story = {
+    render: () => (
+        <Stage>
+            <div
+                className="lift lift--md"
+                style={
+                    {
+                        background: '#2a2a2a',
+                        color: '#fff',
+                        padding: '2em 3em',
+                        borderRadius: 12,
+                        fontWeight: 600,
+                        cursor: 'pointer',
+                        ['--lift-shadow' as string]:
+                            '0 12px 32px rgba(170, 54, 124, 0.45)'
+                    } as React.CSSProperties
+                }
+            >
+                pink-glow lift
+            </div>
+        </Stage>
+    )
+};

--- a/src/effects/Shimmer.mdx
+++ b/src/effects/Shimmer.mdx
@@ -1,0 +1,50 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './Shimmer.stories';
+
+<Meta of={Stories} />
+
+# Shimmer
+
+Animated linear-gradient sweep for skeleton placeholders. Originally on Projects.css `.skeleton-shimmer`. Drop on any element that should look like it's loading.
+
+## When to use
+
+- Skeleton states for cards, avatars, text blocks, image placeholders.
+- Anywhere the alternative would be a static gray box that doesn't communicate "data en route."
+
+## How it works
+
+A 200%-wide linear-gradient (base → highlight → base) is applied as the background, and the background-position scrolls from `200% 0` to `-200% 0` over the duration. The element itself stays the same size; only the gradient sweeps across.
+
+## API
+
+| Variable | Default | Effect |
+|---|---|---|
+| `--shimmer-base` | `rgba(255, 255, 255, 0.04)` | Base tint |
+| `--shimmer-highlight` | `rgba(255, 255, 255, 0.09)` | Sweep tint |
+| `--shimmer-duration` | `1.6s` | Full sweep duration |
+
+`border-radius: 4px` is applied by default — override with your own border-radius if needed.
+
+## Usage
+
+```jsx
+<div className="shimmer" style={{ width: 200, height: 16 }} />
+
+{/* Card skeleton */}
+<div>
+  <div className="shimmer" style={{ height: 24, width: '60%', marginBottom: 16 }} />
+  <div className="shimmer" style={{ height: 140, marginBottom: 16, borderRadius: 8 }} />
+  <div className="shimmer" style={{ height: 14 }} />
+</div>
+```
+
+## Examples
+
+<Canvas of={Stories.SkeletonCard} />
+<Canvas of={Stories.SpeedKnob} />
+
+## Caveats
+
+- **Tints assume a dark background.** The default `rgba(255,255,255,0.04)` and `0.09` are tuned for the portfolio's dark surfaces. On light backgrounds, override with `rgba(0,0,0,0.04)` / `rgba(0,0,0,0.09)`.
+- **Don't shimmer forever.** Pair with real loading state. If the element keeps shimmering past expected load time, the user reads it as broken, not loading.

--- a/src/effects/Shimmer.stories.tsx
+++ b/src/effects/Shimmer.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import './shimmer.css';
+
+/**
+ * `.shimmer` — skeleton placeholder sweep. Originally on Projects.css
+ * `.skeleton-shimmer`. Tune `--shimmer-base`, `--shimmer-highlight`,
+ * `--shimmer-duration`.
+ */
+const Bar = ({
+    width = '100%',
+    height = 16,
+    style
+}: {
+    width?: string;
+    height?: number;
+    style?: React.CSSProperties;
+}) => (
+    <div
+        className="shimmer"
+        style={{ width, height, marginBottom: 12, ...style }}
+    />
+);
+
+const Stage = ({ children }: { children: React.ReactNode }) => (
+    <div
+        style={{
+            background: '#1f1f1f',
+            padding: '4em 3em',
+            minHeight: '60vh'
+        }}
+    >
+        {children}
+    </div>
+);
+
+const meta: Meta = {
+    title: 'Foundations/Motion/Shimmer',
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    'Skeleton-loading sweep. `.shimmer` on any block element with a fixed size.'
+            }
+        }
+    }
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const SkeletonCard: Story = {
+    render: () => (
+        <Stage>
+            <div style={{ maxWidth: 480 }}>
+                <Bar height={24} width="60%" style={{ marginBottom: 24 }} />
+                <Bar height={140} style={{ marginBottom: 24, borderRadius: 8 }} />
+                <Bar height={14} />
+                <Bar height={14} />
+                <Bar height={14} width="80%" />
+            </div>
+        </Stage>
+    )
+};
+
+export const SpeedKnob: Story = {
+    render: () => (
+        <Stage>
+            <p style={{ color: '#fff', marginBottom: 12 }}>fast (0.6s)</p>
+            <Bar
+                height={20}
+                style={
+                    { ['--shimmer-duration' as string]: '0.6s' } as React.CSSProperties
+                }
+            />
+            <p style={{ color: '#fff', margin: '20px 0 12px' }}>default (1.6s)</p>
+            <Bar height={20} />
+            <p style={{ color: '#fff', margin: '20px 0 12px' }}>slow (3s)</p>
+            <Bar
+                height={20}
+                style={
+                    { ['--shimmer-duration' as string]: '3s' } as React.CSSProperties
+                }
+            />
+        </Stage>
+    )
+};

--- a/src/effects/fade-scale-in.css
+++ b/src/effects/fade-scale-in.css
@@ -1,0 +1,25 @@
+/*
+ * .fade-scale-in — modal/lightbox/dialog open transition. Element
+ * fades in (and optionally scales up from a slightly smaller size).
+ * Run-once via animation, not a state toggle.
+ *
+ * Originally on FeaturedImageSlider.css `.featured-image-slider__lightbox`.
+ *
+ * Tune via CSS variables:
+ *   --fade-scale-from    (default 0.96) — starting scale (1 = no scale)
+ *   --fade-scale-duration (default 180ms) — animation duration
+ */
+.fade-scale-in {
+    animation: fade-scale-in var(--fade-scale-duration, 180ms) ease-out;
+}
+
+@keyframes fade-scale-in {
+    from {
+        opacity: 0;
+        transform: scale(var(--fade-scale-from, 0.96));
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}

--- a/src/effects/fan-out.css
+++ b/src/effects/fan-out.css
@@ -1,0 +1,62 @@
+/*
+ * .fan-out — items go from a stacked cluster (negative right margin
+ * pulls each child onto its left neighbor) to a spread row when the
+ * container (or any ancestor) gains .is-open.
+ *
+ * The trick: animate `margin-right` from negative → positive on a 0.3s
+ * transition. The last child stays at 0 in both states so the cluster
+ * grows from the right.
+ *
+ * Originally a happy accident in the navbar mobile-menu social icons
+ * (`nav.has-bg .social-icons a.social-icon`). Captured here so the
+ * effect is reusable on any horizontal cluster.
+ *
+ * Customize via CSS variables on the .fan-out element:
+ *   --fan-out-stacked         (default -2.6em) — closed-state right margin
+ *   --fan-out-spread          (default  1.5em) — open-state right margin
+ *   --fan-out-stacked-opacity (default 0)      — closed-state opacity
+ *   --fan-out-spread-opacity  (default 1)      — open-state opacity
+ *   --fan-out-step-duration   (default 0.3s)   — duration of each phase
+ *
+ * The animation runs in two sequential phases:
+ *   on enter:  opacity 0→1 first, then margin -2.6em→1.5em (fan out)
+ *   on exit:   margin 1.5em→-2.6em first (re-stack), then opacity 1→0
+ * Total cycle = 2 × --fan-out-step-duration per direction.
+ *
+ * Usage:
+ *   <div class="fan-out">
+ *     <div>1</div><div>2</div><div>3</div>
+ *   </div>
+ *   ...later, toggle .is-open on the .fan-out element or any ancestor.
+ */
+/* Closed state — applied as the element transitions back to closed.
+   Margin animates first (re-stack), opacity follows (fade out). */
+.fan-out > * {
+    margin-right: var(--fan-out-stacked, -2.6em);
+    opacity: var(--fan-out-stacked-opacity, 0);
+    transition:
+        margin var(--fan-out-step-duration, 0.3s) ease-in-out,
+        opacity var(--fan-out-step-duration, 0.3s) ease-in-out
+            var(--fan-out-step-duration, 0.3s);
+}
+
+.fan-out > *:last-child {
+    margin-right: 0;
+}
+
+/* Open state — applied as the element transitions to open.
+   Opacity animates first (fade in), margin follows (fan out). */
+.fan-out.is-open > *,
+.is-open .fan-out > * {
+    margin-right: var(--fan-out-spread, 1.5em);
+    opacity: var(--fan-out-spread-opacity, 1);
+    transition:
+        opacity var(--fan-out-step-duration, 0.3s) ease-in-out,
+        margin var(--fan-out-step-duration, 0.3s) ease-in-out
+            var(--fan-out-step-duration, 0.3s);
+}
+
+.fan-out.is-open > *:last-child,
+.is-open .fan-out > *:last-child {
+    margin-right: 0;
+}

--- a/src/effects/float.css
+++ b/src/effects/float.css
@@ -1,0 +1,27 @@
+/*
+ * .float — gentle vertical bob, infinite. Originally on the Hero
+ * bitmoji (.floating-image). Generic enough for any decorative
+ * floating element.
+ *
+ * Customize via CSS variables:
+ *   --float-distance (default 1em) — peak displacement up/down
+ *   --float-duration (default 6s)  — full cycle duration
+ *
+ * The element starts mid-cycle and oscillates symmetrically — no jump
+ * on mount.
+ */
+.float {
+    animation: float-updown var(--float-duration, 6s) ease-in-out infinite;
+}
+
+@keyframes float-updown {
+    0% {
+        transform: translateY(calc(-1 * var(--float-distance, 1em)));
+    }
+    50% {
+        transform: translateY(var(--float-distance, 1em));
+    }
+    100% {
+        transform: translateY(calc(-1 * var(--float-distance, 1em)));
+    }
+}

--- a/src/effects/frosted.css
+++ b/src/effects/frosted.css
@@ -1,0 +1,21 @@
+/*
+ * .frosted — the portfolio's signature glass material. Translucent
+ * white tint over a backdrop blur+saturate. Used 8+ times across
+ * MomentumTabs, FeaturedImageSlider dots/arrows, and project cards.
+ *
+ * Customize via CSS variables on the element:
+ *   --frosted-bg       (default rgba(255,255,255,0.05)) — tint color
+ *   --frosted-blur     (default 10px)                   — blur radius
+ *   --frosted-saturate (default 1.3)                    — saturation
+ *
+ * Note: backdrop-filter requires a non-opaque background-color on the
+ * element AND a non-transparent backdrop behind it. Falls back to plain
+ * tint on browsers without backdrop-filter support.
+ */
+.frosted {
+    background: var(--frosted-bg, rgba(255, 255, 255, 0.05));
+    backdrop-filter: blur(var(--frosted-blur, 10px))
+        saturate(var(--frosted-saturate, 1.3));
+    -webkit-backdrop-filter: blur(var(--frosted-blur, 10px))
+        saturate(var(--frosted-saturate, 1.3));
+}

--- a/src/effects/gradient-pair.css
+++ b/src/effects/gradient-pair.css
@@ -1,0 +1,80 @@
+/*
+ * .gradient-pair — two adjacent buttons that share a continuous gradient.
+ * The primary is filled; the secondary is outlined and fills L→R on hover.
+ * When the secondary is hovered, the primary's gradient angle rotates
+ * 180° so the visual gradient appears to flow across both buttons.
+ *
+ * Origin: PreFooter "The Repo" + "Storybook" CTA pair.
+ *
+ * Tune via CSS variables on the .gradient-pair container:
+ *   --gp-color-1       (default #aa367c) — gradient stop 1
+ *   --gp-color-2       (default #4a2fbd) — gradient stop 2
+ *   --gp-angle-base    (default 131deg)  — primary's base angle
+ *   --gp-angle-flipped (default 311deg)  — primary's hovered-state angle
+ *
+ * Browser support:
+ *   - Requires @property (Safari 16.4+, Chrome 85+, Firefox 128+).
+ *   - Uses :has() for cross-button coordination (Safari 15.4+,
+ *     Chrome 105+, Firefox 121+).
+ *
+ * Usage:
+ *   <div class="gradient-pair">
+ *     <a class="gradient-pair__primary">Primary</a>
+ *     <a class="gradient-pair__secondary">Secondary</a>
+ *   </div>
+ */
+@property --gp-angle {
+    syntax: '<angle>';
+    inherits: false;
+    initial-value: 131deg;
+}
+
+.gradient-pair__primary {
+    --gp-angle: var(--gp-angle-base, 131deg);
+    background: linear-gradient(
+        var(--gp-angle),
+        var(--gp-color-1, #aa367c) 28%,
+        var(--gp-color-2, #4a2fbd) 71%
+    );
+    color: #fff;
+    transition: --gp-angle 0.3s ease-in-out;
+}
+
+.gradient-pair__secondary {
+    position: relative;
+    overflow: hidden;
+    isolation: isolate;
+    background: transparent;
+    color: var(--gp-color-2, #4a2fbd);
+    border: 2px solid var(--gp-color-2, #4a2fbd);
+    transition: color 0.25s ease;
+}
+
+.gradient-pair__secondary::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 0;
+    height: 100%;
+    background: linear-gradient(
+        var(--gp-angle-base, 131deg),
+        var(--gp-color-1, #aa367c) 28%,
+        var(--gp-color-2, #4a2fbd) 71%
+    );
+    transition: width 0.3s ease-in-out;
+    z-index: -1;
+    pointer-events: none;
+}
+
+.gradient-pair__secondary:hover {
+    color: #fff;
+}
+
+.gradient-pair__secondary:hover::before {
+    width: 100%;
+}
+
+.gradient-pair:has(.gradient-pair__secondary:hover) .gradient-pair__primary {
+    --gp-angle: var(--gp-angle-flipped, 311deg);
+}

--- a/src/effects/index.css
+++ b/src/effects/index.css
@@ -1,0 +1,12 @@
+/* ==== Foundations / Effects — barrel ====
+   Imports every effect class so a single global import (in src/index.tsx)
+   makes all of them available. Stories import their per-effect CSS file
+   directly so they render in isolation in Storybook. */
+
+@import './fan-out.css';
+@import './lift.css';
+@import './frosted.css';
+@import './float.css';
+@import './shimmer.css';
+@import './fade-scale-in.css';
+@import './gradient-pair.css';

--- a/src/effects/lift.css
+++ b/src/effects/lift.css
@@ -1,0 +1,31 @@
+/*
+ * .lift — translateY + shadow boost on hover. The portfolio's standard
+ * "this is interactive" feedback. Used by .cta-btn, .sb-frame, and the
+ * featured project card. Apply to any hoverable element.
+ *
+ * Variants:
+ *   .lift          → -2px (subtle, default — mirrors .cta-btn)
+ *   .lift--md      → -4px (mirrors .sb-frame)
+ *   .lift--lg      → -6px (cards / large surfaces)
+ *
+ * Override the shadow by setting --lift-shadow on the element. The
+ * default shadow is a neutral dark drop suitable for light surfaces.
+ */
+.lift {
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.lift:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--lift-shadow, 0 8px 18px rgba(20, 20, 40, 0.25));
+}
+
+.lift.lift--md:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--lift-shadow, 0 14px 32px rgba(20, 20, 40, 0.3));
+}
+
+.lift.lift--lg:hover {
+    transform: translateY(-6px);
+    box-shadow: var(--lift-shadow, 0 18px 40px rgba(20, 20, 40, 0.35));
+}

--- a/src/effects/shimmer.css
+++ b/src/effects/shimmer.css
@@ -1,0 +1,30 @@
+/*
+ * .shimmer — animated linear-gradient sweep for skeleton placeholders.
+ * Originally on Projects.css `.skeleton-shimmer`. Drop on any element
+ * that should look like it's loading.
+ *
+ * Tune via CSS variables:
+ *   --shimmer-base      (default rgba(255,255,255,0.04)) — base tint
+ *   --shimmer-highlight (default rgba(255,255,255,0.09)) — sweep tint
+ *   --shimmer-duration  (default 1.6s) — full sweep duration
+ */
+.shimmer {
+    background: linear-gradient(
+        90deg,
+        var(--shimmer-base, rgba(255, 255, 255, 0.04)) 25%,
+        var(--shimmer-highlight, rgba(255, 255, 255, 0.09)) 50%,
+        var(--shimmer-base, rgba(255, 255, 255, 0.04)) 75%
+    );
+    background-size: 200% 100%;
+    animation: shimmer-sweep var(--shimmer-duration, 1.6s) ease-in-out infinite;
+    border-radius: 4px;
+}
+
+@keyframes shimmer-sweep {
+    0% {
+        background-position: 200% 0;
+    }
+    100% {
+        background-position: -200% 0;
+    }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
+import "./effects/index.css";
 import App from "./components/App";
 
 const root = ReactDOM.createRoot(document.getElementById("root")!);


### PR DESCRIPTION
## Summary
Promotes #183 to main:
- Mobile polish (MomentumTabs, hero centering, sb-mock iframe, navbar bg, border-radius)
- Reusable effects library at \`src/effects/\` (7 utility classes + stories + MDX docs)
- Storybook docs (Welcome, Foundations/Overview, 7 per-foundation pages)

PR #175 (coverage script + audit baseline) is still open against \`dev\` and not in this batch.